### PR TITLE
Use mwccgap

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "tools/asm-differ"]
 	path = tools/asm-differ
 	url = https://github.com/simonlindholm/asm-differ
+[submodule "tools/mwccgap"]
+	path = tools/mwccgap
+	url = https://github.com/mkst/mwccgap.git

--- a/config/anniversary/sfiii.anniversary.yaml
+++ b/config/anniversary/sfiii.anniversary.yaml
@@ -9,7 +9,7 @@ options:
   asset_path: assets/anniversary
   build_path: build/anniversary
   ld_script_path: build/anniversary/THIRD_U.BIN.ld
-  symbol_addrs_path: 
+  symbol_addrs_path:
     - config/anniversary/symbols/syms_cri_libadxe.txt
     - config/anniversary/symbols/syms_gcc_libc.txt
     - config/anniversary/symbols/syms_label_overrides.txt
@@ -48,12 +48,17 @@ options:
     - config/anniversary/symbols/syms_sfiii.txt
   undefined_funcs_auto_path: config/anniversary/undefined_funcs_auto.txt
   undefined_syms_auto_path: config/anniversary/undefined_syms_auto.txt
-  find_file_boundaries: False 
+  find_file_boundaries: False
   section_order: [".text", ".data", ".rodata", ".sdata", ".sbss", ".bss"]
   subalign: null
   migrate_rodata_to_functions: False
   gp_value: 0x57A3F0
   rodata_string_guesser_level: 0
+
+  asm_inc_header: |
+    .set noat      /* allow manual use of $at */
+    .set noreorder /* don't insert nops after branches */
+    .include "macro.inc"
 
 sha1: cf58495054c31ad852175c66e9ca04d5094f000e
 
@@ -118,7 +123,7 @@ segments:
 
       - [0x015DE0, c, sf33rd/AcrSDK/common/fbms]
       - [0x016030, c, sf33rd/AcrSDK/common/memfound]
-      - [0x016200, asm, sf33rd/AcrSDK/common/memmgr]
+      - [0x016200, c, sf33rd/AcrSDK/common/memmgr]
       - [0x017380, c, sf33rd/AcrSDK/common/mlPAD]
       - [0x018D70, c, sf33rd/AcrSDK/common/plapx]
       - [0x0199B0, c, sf33rd/AcrSDK/common/plbmp]

--- a/include/common.h
+++ b/include/common.h
@@ -5,4 +5,6 @@
 
 #define NULL 0
 
+#define INCLUDE_ASM(FOLDER, NAME)
+
 #endif

--- a/src/anniversary/sf33rd/AcrSDK/common/memmgr.c
+++ b/src/anniversary/sf33rd/AcrSDK/common/memmgr.c
@@ -3,3 +3,35 @@
 
 static u32 plmemPullHandle(MEM_MGR *memmgr);                // Range: 0x116F60 -> 0x116FFC
 static void plmemAppendBlockList(MEM_MGR *memmgr, u32 han); // Range: 0x117000 -> 0x1171F8
+
+INCLUDE_ASM("asm/anniversary/nonmatchings/sf33rd/AcrSDK/common/memmgr", plmemInit);
+
+INCLUDE_ASM("asm/anniversary/nonmatchings/sf33rd/AcrSDK/common/memmgr", plmemRegister);
+
+INCLUDE_ASM("asm/anniversary/nonmatchings/sf33rd/AcrSDK/common/memmgr", plmemRegisterAlign);
+
+INCLUDE_ASM("asm/anniversary/nonmatchings/sf33rd/AcrSDK/common/memmgr", plmemRegisterS);
+
+INCLUDE_ASM("asm/anniversary/nonmatchings/sf33rd/AcrSDK/common/memmgr", plmemTemporaryUse);
+
+INCLUDE_ASM("asm/anniversary/nonmatchings/sf33rd/AcrSDK/common/memmgr", plmemRetrieve);
+
+INCLUDE_ASM("asm/anniversary/nonmatchings/sf33rd/AcrSDK/common/memmgr", plmemRelease);
+
+INCLUDE_ASM("asm/anniversary/nonmatchings/sf33rd/AcrSDK/common/memmgr", plmemCompact);
+
+#if 1
+u32 plmemGetSpace(MEM_MGR *memmgr) {
+    return memmgr->memsize - memmgr->used_size;
+}
+#else
+INCLUDE_ASM("asm/anniversary/nonmatchings/sf33rd/AcrSDK/common/memmgr", plmemGetSpace);
+#endif
+
+INCLUDE_ASM("asm/anniversary/nonmatchings/sf33rd/AcrSDK/common/memmgr", plmemGetFreeSpace);
+
+INCLUDE_ASM("asm/anniversary/nonmatchings/sf33rd/AcrSDK/common/memmgr", plmemPullHandle);
+
+INCLUDE_ASM("asm/anniversary/nonmatchings/sf33rd/AcrSDK/common/memmgr", plmemAppendBlockList);
+
+INCLUDE_ASM("asm/anniversary/nonmatchings/sf33rd/AcrSDK/common/memmgr", plmemDeleteBlockList);


### PR DESCRIPTION
This PR adds the [mwccgap](https://github.com/mkst/mwccgap) tool which allows functions to be replaced one-by-one within a c file.

I have re-split `src/anniversary/sf33rd/AcrSDK/common/memmgr.c` by way of example - matched 1 simple function.

**NOTE:** This is only the 2nd project to use mwccgap (the other is SOTN, where it is used for the PSP version) - please let me know of any issues you find.