### PR TITLE
Fix pointer truncation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,24 @@ EEGCC_FLAGS := $(PS2_INCLUDES) -O2 -G0 -c $(PS2_DEFINES) -DXPT_TGT_EE
 AS_FLAGS += -EL -I $(INCLUDE_DIR) -G 128 -march=r5900 -mabi=eabi -no-pad-sections
 LD_FLAGS := -main func_00100008 -map
 
+CLANG_WARNINGS := -Wall -Werror
+CLANG_WARNINGS += -Wno-macro-redefined -Wno-deprecated-non-prototype
+CLANG_WARNINGS += -Wno-missing-braces -Wno-self-assign -Wno-format
+CLANG_WARNINGS += -Wno-tautological-constant-out-of-range-compare -Wno-tautological-overlap-compare
+CLANG_WARNINGS += -Wno-gcc-compat -Wno-unknown-pragmas -Wno-c2x-extensions
+CLANG_WARNINGS += -Wno-unused-value -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unused-comparison -Wno-unused-function
+
+# These should be enabled in the future
+CLANG_WARNINGS += -Wno-int-to-pointer-cast
+CLANG_WARNINGS += -Wno-int-conversion
+CLANG_WARNINGS += -Wno-incompatible-pointer-types
+CLANG_WARNINGS += -Wno-incompatible-function-pointer-types
+CLANG_WARNINGS += -Wno-pointer-sign
+CLANG_WARNINGS += -Wno-shift-count-overflow
+
 CLANG_INCLUDES := $(COMMON_INCLUDES)
-CLANG_FLAGS := $(CLANG_INCLUDES) -DTARGET_SDL3 -DXPT_TGT_EE -D_POSIX_C_SOURCE -std=c99
-CLANG_FLAGS += -Wno-c2x-extensions -Wno-int-conversion -Wno-incompatible-function-pointer-types -w
+CLANG_FLAGS := $(CLANG_INCLUDES) $(CLANG_WARNINGS) -DTARGET_SDL3 -DXPT_TGT_EE -D_POSIX_C_SOURCE -std=c99
+
 CLANG_LINKER_FLAGS := -lz -lm -g
 
 ifneq ($(PLATFORM),ps2)

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ AS_FLAGS += -EL -I $(INCLUDE_DIR) -G 128 -march=r5900 -mabi=eabi -no-pad-section
 LD_FLAGS := -main func_00100008 -map
 
 CLANG_WARNINGS := -Wall -Werror
+CLANG_WARNINGS += -Wpointer-to-int-cast
 CLANG_WARNINGS += -Wno-macro-redefined -Wno-deprecated-non-prototype
 CLANG_WARNINGS += -Wno-missing-braces -Wno-self-assign -Wno-format
 CLANG_WARNINGS += -Wno-tautological-constant-out-of-range-compare -Wno-tautological-overlap-compare

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,10 @@ CLANG_FLAGS := $(CLANG_INCLUDES) -DTARGET_SDL3 -DXPT_TGT_EE -D_POSIX_C_SOURCE -s
 CLANG_FLAGS += -Wno-c2x-extensions -Wno-int-conversion -Wno-incompatible-function-pointer-types -w
 CLANG_LINKER_FLAGS := -lz -lm -g
 
-CLANG_FLAGS += $(shell pkg-config --cflags sdl3)
-CLANG_LINKER_FLAGS += $(shell pkg-config --libs sdl3)
+ifneq ($(PLATFORM),ps2)
+	CLANG_FLAGS += $(shell pkg-config --cflags sdl3)
+	CLANG_LINKER_FLAGS += $(shell pkg-config --libs sdl3)
+endif
 
 # Files
 

--- a/include/cri/cri_adxf.h
+++ b/include/cri/cri_adxf.h
@@ -15,6 +15,8 @@
 /*      Include file */
 /****************************************************************************/
 
+#include "types.h"
+
 #include "cri/ee/cri_xpt.h"
 #include "sj.h"
 
@@ -218,10 +220,10 @@ typedef struct _adxf_add_info {
 #ifndef ADXF_CMD_HSTRY_DEFINED
 #define ADXF_CMD_HSTRY_DEFINED
 typedef struct _adxf_cmd_hstry {
-    Uint8 cmdid;   /*	コマンド(関数)ID					*/
-    Uint8 fg;      /*	関数の入り口か出口かを示すフラグ	*/
-    Uint16 ncall;  /*	コマンドの呼び出し回数				*/
-    Sint32 prm[3]; /*	コマンドパラメータ					*/
+    Uint8 cmdid;     /*	コマンド(関数)ID					*/
+    Uint8 fg;        /*	関数の入り口か出口かを示すフラグ	*/
+    Uint16 ncall;    /*	コマンドの呼び出し回数				*/
+    intptr_t prm[3]; /*	コマンドパラメータ					*/
 } ADXF_CMD_HSTRY;
 #endif
 

--- a/include/cri/private/libadxe/adx_bsc.h
+++ b/include/cri/private/libadxe/adx_bsc.h
@@ -1,11 +1,13 @@
 #ifndef ADX_BSC_H
 #define ADX_BSC_H
 
+#include "types.h"
+
 #include <cri/cri_xpts.h>
 #include <cri/private/libadxe/structs.h>
 
 void ADXB_Init();
-ADXB ADXB_Create(Sint32 arg0, Sint32 arg1, Sint32 arg2, Sint32 arg3);
+ADXB ADXB_Create(Sint32 arg0, void *arg1, Sint32 arg2, Sint32 arg3);
 void ADXB_Destroy(ADXB);
 void ADXB_Stop(ADXB);
 Sint32 ADXB_GetSfreq(ADXB adxb);
@@ -14,8 +16,8 @@ Sint32 ADXB_GetOutBps(ADXB adxb);
 Sint32 ADXB_GetTotalNumSmpl(ADXB adxb);
 Sint32 ADXB_GetAinfLen(ADXB adxb);
 Sint16 ADXB_GetDefOutVol(ADXB adxb);
-Sint32 ADXB_GetPcmBuf(ADXB adxb); // Returns a void*?
-void ADXB_EntryGetWrFunc(ADXB adxb, Sint32 (*get_wr)(void *, Sint32 *, Sint32 *, Sint32 *), void *object);
+void *ADXB_GetPcmBuf(ADXB adxb);
+void ADXB_EntryGetWrFunc(ADXB adxb, void *(*get_wr)(void *, ptrdiff_t *, Sint32 *, Sint32 *), void *object);
 Sint32 ADXB_GetFormat(ADXB adxb);
 Sint32 ADXB_DecodeHeader(ADXB adxb, void *header, Sint32 len);
 

--- a/include/cri/private/libadxe/adx_fs.h
+++ b/include/cri/private/libadxe/adx_fs.h
@@ -1,10 +1,12 @@
 #ifndef ADX_FS_H
 #define ADX_FS_H
 
+#include "types.h"
+
 #include <cri/ee/cri_xpt.h>
 #include <cri_adxf.h>
 
-void adxf_SetCmdHstry(Sint32 ncall, Sint32 fg, Sint32 ptid, Sint32 flid, Sint32 type);
+void adxf_SetCmdHstry(Sint32 ncall, Sint32 fg, intptr_t ptid, intptr_t flid, intptr_t type);
 ADXF adxf_CreateAdxFs();
 Sint32 adxf_SetAfsFileInfo(ADXF adxf, Sint32 ptid, Sint32 flid);
 void ADXF_Close(ADXF adxf);

--- a/include/cri/private/libadxe/dtr.h
+++ b/include/cri/private/libadxe/dtr.h
@@ -6,7 +6,7 @@
 #include <cri/cri_xpts.h>
 #include <cri/sj.h>
 
-DTR DTR_Create(SJ sj, Sint32 arg1);
+DTR DTR_Create(SJ sj, SJ arg1);
 void DTR_Destroy(DTR dtr);
 void DTR_Start(DTR dtr);
 void DTR_Stop(DTR dtr);

--- a/include/cri/private/libadxe/dtx.h
+++ b/include/cri/private/libadxe/dtx.h
@@ -1,6 +1,8 @@
 #ifndef DTX_H
 #define DTX_H
 
+#include "types.h"
+
 #include <cri/private/libadxe/structs.h>
 
 #include <cri/cri_xpts.h>
@@ -12,7 +14,7 @@ DTX DTX_Create(Sint32 id, void *eewk, void *iopwk, Sint32 wklen);
 void DTX_Destroy(DTX dtx);
 void DTX_SetRcvCbf(DTX dtx, void (*func)(), void *object);
 void DTX_SetSndCbf(DTX dtx, void (*func)(), void *object);
-Sint32 DTX_CallUrpc(Sint32 arg0, Sint32 *args, Sint32 arg_num, Sint32 *arg3, Sint32 arg4);
+intptr_t DTX_CallUrpc(Uint32 call_id, intptr_t *snd_buf, Sint32 snd_buf_len, intptr_t *rcv_buf, Sint32 rcv_buf_len);
 void DTX_Finish();
 void DTX_ExecServer();
 

--- a/include/cri/private/libadxe/sj_rbf.h
+++ b/include/cri/private/libadxe/sj_rbf.h
@@ -4,7 +4,7 @@
 #include <cri/cri_xpts.h>
 #include <cri/sj.h>
 
-Sint32 SJRBF_GetBufPtr(SJ sj);
+void *SJRBF_GetBufPtr(SJ sj);
 Sint32 SJRBF_GetBufSize(SJ sj);
 Sint32 SJRBF_GetXtrSize(SJ sj);
 

--- a/include/cri/private/libadxe/sjr_clt.h
+++ b/include/cri/private/libadxe/sjr_clt.h
@@ -4,8 +4,8 @@
 #include <cri/cri_xpts.h>
 
 void SJRMT_Init();
-Sint32 SJUNI_CreateRmt(Sint32, Sint8 *, Sint32); // Probably returns a pointer
-void SJRMT_Destroy(Sint32);
+void *SJUNI_CreateRmt(Sint32, Sint8 *, Sint32);
+void SJRMT_Destroy(void *);
 void SJRMT_Finish();
 
 #endif

--- a/include/cri/private/libadxe/sjx.h
+++ b/include/cri/private/libadxe/sjx.h
@@ -1,12 +1,16 @@
 #ifndef SJX_H
 #define SJX_H
 
+#include "types.h"
+
+#include <cri/private/libadxe/structs.h>
+
 #include <cri/cri_xpts.h>
 #include <cri/sj.h>
 
 void SJX_Init();
-Sint32 SJX_Create(SJ, Sint32, Sint32); // Probably returns a pointer
-void SJX_Destroy(Sint32);
+SJX SJX_Create(SJ, void *, Sint32);
+void SJX_Destroy(SJX);
 void SJX_Finish();
 void SJX_ExecServer();
 

--- a/include/cri/private/libadxe/structs.h
+++ b/include/cri/private/libadxe/structs.h
@@ -151,6 +151,43 @@ typedef struct {
 
 typedef ADXAMP_OBJ *ADXAMP;
 
+// SJX
+
+#define SJX_MAX_OBJ 32
+
+typedef struct {
+    Sint32 unk0;
+    SJ sj;
+} SJX_UNK_0;
+
+typedef struct {
+    Sint8 unk0;
+    Sint8 id;
+    Sint16 unk2;
+    SJX_UNK_0 *unk4;
+    SJCK chunk;
+} SJX_UNK_1;
+
+typedef struct {
+    Sint32 count;
+    Sint32 reserved4;
+    Sint32 reserved8;
+    Sint32 reservedC;
+    SJX_UNK_1 items[0];
+} SJX_UNK_2;
+
+typedef struct {
+    Sint8 used;
+    Sint8 unk1;
+    Sint16 unk2;
+    SJ sj;
+    void *unk8;
+    Sint32 unkC;
+    SJX_UNK_0 *unk10;
+} SJX_OBJ;
+
+typedef SJX_OBJ *SJX;
+
 // PS2PSJ
 
 typedef struct {
@@ -158,7 +195,7 @@ typedef struct {
     char pad1[3];
     void *unk4;
     SJ unk8;
-    Sint32 unkC;
+    SJX unkC;
     SJCK chunk;
 } PS2PSJ_OBJ;
 
@@ -255,7 +292,7 @@ typedef struct {
     Sint8 read_flg;
     Sint8 unk3;
     SJ sj;
-    Sint32 cvfs;
+    void *cvfs;
     Sint32 unkC; // some offset
     Sint32 file_len;
     Sint32 file_sct;
@@ -393,42 +430,5 @@ typedef struct {
     Sint32 unk8;
     Sint32 unkC;
 } DVG_FLIST_TBL;
-
-// SJX
-
-#define SJX_MAX_OBJ 32
-
-typedef struct {
-    Sint32 unk0;
-    SJ sj;
-} SJX_UNK_0;
-
-typedef struct {
-    Sint8 unk0;
-    Sint8 id;
-    Sint16 unk2;
-    SJX_UNK_0 *unk4;
-    SJCK chunk;
-} SJX_UNK_1;
-
-typedef struct {
-    Sint32 count;
-    Sint32 reserved4;
-    Sint32 reserved8;
-    Sint32 reservedC;
-    SJX_UNK_1 items[0];
-} SJX_UNK_2;
-
-typedef struct {
-    Sint8 used;
-    Sint8 unk1;
-    Sint16 unk2;
-    SJ sj;
-    void *unk8;
-    Sint32 unkC;
-    SJX_UNK_0 *unk10;
-} SJX_OBJ;
-
-typedef SJX_OBJ *SJX;
 
 #endif

--- a/include/cri/private/libadxe/structs.h
+++ b/include/cri/private/libadxe/structs.h
@@ -1,6 +1,8 @@
 #ifndef LIBADXE_STRUCTS_H
 #define LIBADXE_STRUCTS_H
 
+#include "types.h"
+
 #include <cri/cri_xpts.h>
 #include <cri/sj.h>
 
@@ -32,7 +34,7 @@ typedef struct {             // offset in ADXB
     /* 0x08 */ Sint32 unk8;  // 0x50
     /* 0x0C */ Sint32 unkC;  // 0x54
     /* 0x10 */ Sint32 unk10; // 0x58
-    /* 0x14 */ Sint32 unk14; // 0x5C
+    /* 0x14 */ void *unk14;  // 0x5C
     /* 0x18 */ Sint32 unk18; // 0x60
     /* 0x1C */ Sint32 unk1C; // 0x64
     /* 0x20 */ Sint32 unk20; // 0x68
@@ -62,12 +64,12 @@ typedef struct {
     /* 0x30 */ Sint32 unk30;
     /* 0x34 */ Sint32 unk34;
     /* 0x38 */ Sint32 unk38;
-    /* 0x3C */ Sint32 unk3C;
+    /* 0x3C */ void *unk3C;
     /* 0x40 */ Sint32 unk40;
     /* 0x44 */ Sint32 unk44;
     /* 0x48 */ ADXB_UNK unk48;
     /* 0x74 */ Sint32 unk74;
-    /* 0x78 */ Sint32 (*get_wr)(void *, Sint32 *, Sint32 *, Sint32 *);
+    /* 0x78 */ void *(*get_wr)(void *, ptrdiff_t *, Sint32 *, Sint32 *);
     /* 0x7C */ void *object;
     /* 0x80 */ void (*add_wr)(void *, Sint32, Sint32);
     /* 0x84 */ Sint32 unk84;
@@ -154,7 +156,7 @@ typedef ADXAMP_OBJ *ADXAMP;
 typedef struct {
     Sint8 used;
     char pad1[3];
-    Sint32 unk4;
+    void *unk4;
     SJ unk8;
     Sint32 unkC;
     SJCK chunk;
@@ -190,7 +192,7 @@ typedef struct {
     PS2PSJ psj[2];
     DTR dtr[2];
     SJ sjo[2];
-    Sint32 unk20;
+    intptr_t unk20;
     Sint32 unk24;
     Sint32 unk28;
     Sint32 unk2C;
@@ -228,7 +230,7 @@ typedef struct {
     Sint8 unk1;
     Sint8 unk2;
     Sint8 unk3;
-    Sint32 unk4;
+    void *unk4;
     Sint32 unk8;
     void *unkC;
     Sint32 unk10;
@@ -391,5 +393,42 @@ typedef struct {
     Sint32 unk8;
     Sint32 unkC;
 } DVG_FLIST_TBL;
+
+// SJX
+
+#define SJX_MAX_OBJ 32
+
+typedef struct {
+    Sint32 unk0;
+    SJ sj;
+} SJX_UNK_0;
+
+typedef struct {
+    Sint8 unk0;
+    Sint8 id;
+    Sint16 unk2;
+    SJX_UNK_0 *unk4;
+    SJCK chunk;
+} SJX_UNK_1;
+
+typedef struct {
+    Sint32 count;
+    Sint32 reserved4;
+    Sint32 reserved8;
+    Sint32 reservedC;
+    SJX_UNK_1 items[0];
+} SJX_UNK_2;
+
+typedef struct {
+    Sint8 used;
+    Sint8 unk1;
+    Sint16 unk2;
+    SJ sj;
+    void *unk8;
+    Sint32 unkC;
+    SJX_UNK_0 *unk10;
+} SJX_OBJ;
+
+typedef SJX_OBJ *SJX;
 
 #endif

--- a/include/sf33rd/AcrSDK/MiddleWare/PS2/CapSndEng/cse.h
+++ b/include/sf33rd/AcrSDK/MiddleWare/PS2/CapSndEng/cse.h
@@ -28,11 +28,11 @@ typedef struct {
 
 typedef struct {
     // total size: 0x14
-    u32 cmd;    // offset 0x0, size 0x4
-    u32 guid;   // offset 0x4, size 0x4
-    u32 e_addr; // offset 0x8, size 0x4
-    u32 s_addr; // offset 0xC, size 0x4
-    u32 size;   // offset 0x10, size 0x4
+    u32 cmd;          // offset 0x0, size 0x4
+    u32 guid;         // offset 0x4, size 0x4
+    uintptr_t e_addr; // offset 0x8, size 0x4
+    u32 s_addr;       // offset 0xC, size 0x4
+    u32 size;         // offset 0x10, size 0x4
 } CSE_SPUID_PARAM;
 
 s32 cseInitSndDrv();

--- a/include/sf33rd/AcrSDK/common/memfound.h
+++ b/include/sf33rd/AcrSDK/common/memfound.h
@@ -5,16 +5,16 @@
 #include "structs.h"
 #include "types.h"
 
-extern MEM_BLOCK sysmemblock[4096]; // size: 0x10000, address: 0x584C80
+extern MEM_BLOCK sysmemblock[4096];
 
-void mflInit(void *mem_ptr, s32 memsize, s32 memalign); // Range: 0x115FB0 -> 0x115FFC
-u32 mflGetSpace();                                      // Range: 0x116000 -> 0x116024
-u32 mflGetFreeSpace();                                  // Range: 0x116030 -> 0x116054
-u32 mflRegisterS(s32 len);                              // Range: 0x116060 -> 0x11608C
-u32 mflRegister(s32 len);                               // Range: 0x116090 -> 0x1160BC
-void *mflTemporaryUse(s32 len);                         // Range: 0x1160C0 -> 0x1160EC
-void *mflRetrieve(u32 handle);                          // Range: 0x1160F0 -> 0x11611C
-s32 mflRelease(u32 handle);                             // Range: 0x116120 -> 0x11614C
-void *mflCompact();                                     // Range: 0x116150 -> 0x116174
+void mflInit(void *mem_ptr, s32 memsize, s32 memalign);
+u32 mflGetSpace();
+size_t mflGetFreeSpace();
+u32 mflRegisterS(s32 len);
+u32 mflRegister(s32 len);
+void *mflTemporaryUse(s32 len);
+void *mflRetrieve(u32 handle);
+s32 mflRelease(u32 handle);
+void *mflCompact();
 
 #endif

--- a/include/sf33rd/AcrSDK/common/memmgr.h
+++ b/include/sf33rd/AcrSDK/common/memmgr.h
@@ -39,6 +39,6 @@ void *plmemRetrieve(MEM_MGR *memmgr, u32 handle);            // Range: 0x116AB0 
 s32 plmemRelease(MEM_MGR *memmgr, u32 handle);               // Range: 0x116B20 -> 0x116BFC
 void *plmemCompact(MEM_MGR *memmgr);                         // Range: 0x116C00 -> 0x116E9C
 u32 plmemGetSpace(MEM_MGR *memmgr);                          // Range: 0x116EA0 -> 0x116EC8
-u32 plmemGetFreeSpace(MEM_MGR *memmgr);                      // Range: 0x116ED0 -> 0x116F5C
+size_t plmemGetFreeSpace(MEM_MGR *memmgr);                   // Range: 0x116ED0 -> 0x116F5C
 
 #endif

--- a/include/sf33rd/AcrSDK/common/plcommon.h
+++ b/include/sf33rd/AcrSDK/common/plcommon.h
@@ -32,28 +32,28 @@ typedef struct {
 
 typedef struct {
     // total size: 0x3C
-    u32 flag;        // offset 0x0, size 0x4
-    u32 desc;        // offset 0x4, size 0x4
-    u32 size;        // offset 0x8, size 0x4
-    u32 bitdepth;    // offset 0xC, size 0x4
-    s16 block_size;  // offset 0x10, size 0x2
-    s16 block_align; // offset 0x12, size 0x2
-    s16 tbp;         // offset 0x14, size 0x2
-    s16 tw;          // offset 0x16, size 0x2
-    s16 th;          // offset 0x18, size 0x2
-    s16 width;       // offset 0x1A, size 0x2
-    s16 height;      // offset 0x1C, size 0x2
-    u32 format;      // offset 0x20, size 0x4
-    u32 mem_handle;  // offset 0x24, size 0x4
-    s16 dma_width;   // offset 0x28, size 0x2
-    s16 dma_height;  // offset 0x2A, size 0x2
-    u32 lock_ptr;    // offset 0x2C, size 0x4
-    u32 tex_num;     // offset 0x30, size 0x4
-    s8 be_flag;      // offset 0x34, size 0x1
-    s8 vram_on_flag; // offset 0x35, size 0x1
-    s8 dma_type;     // offset 0x36, size 0x1
-    u8 lock_flag;    // offset 0x37, size 0x1
-    void *wkVram;    // offset 0x38, size 0x4
+    u32 flag;           // offset 0x0, size 0x4
+    u32 desc;           // offset 0x4, size 0x4
+    u32 size;           // offset 0x8, size 0x4
+    u32 bitdepth;       // offset 0xC, size 0x4
+    s16 block_size;     // offset 0x10, size 0x2
+    s16 block_align;    // offset 0x12, size 0x2
+    s16 tbp;            // offset 0x14, size 0x2
+    s16 tw;             // offset 0x16, size 0x2
+    s16 th;             // offset 0x18, size 0x2
+    s16 width;          // offset 0x1A, size 0x2
+    s16 height;         // offset 0x1C, size 0x2
+    u32 format;         // offset 0x20, size 0x4
+    u32 mem_handle;     // offset 0x24, size 0x4
+    s16 dma_width;      // offset 0x28, size 0x2
+    s16 dma_height;     // offset 0x2A, size 0x2
+    uintptr_t lock_ptr; // offset 0x2C, size 0x4
+    u32 tex_num;        // offset 0x30, size 0x4
+    s8 be_flag;         // offset 0x34, size 0x1
+    s8 vram_on_flag;    // offset 0x35, size 0x1
+    s8 dma_type;        // offset 0x36, size 0x1
+    u8 lock_flag;       // offset 0x37, size 0x1
+    void *wkVram;       // offset 0x38, size 0x4
 } FLTexture;
 
 #endif

--- a/include/sf33rd/AcrSDK/ps2/flps2asm.h
+++ b/include/sf33rd/AcrSDK/ps2/flps2asm.h
@@ -3,17 +3,17 @@
 
 #include "types.h"
 
-void flPS2_Mem_move(const void *src, void *dst, u32 len);
-void flPS2_Mem_move16(const void *src, void *dst, u32 len);
-void flPS2_Mem_move16_8A(const void *src, void *dst, u32 len);
-void flPS2_Mem_move16_16A(const void *src, void *dst, u32 len);
-void flPS2_Mem_move32(const void *src, void *dst, u32 len);
-void flPS2_Mem_move32_8A(const void *src, void *dst, u32 len);
-void flPS2_Mem_move32_16A(const void *src, void *dst, u32 len);
-void flPS2_Mem_move64(const void *src, void *dst, u32 len);
-void flPS2_Clear_Mem(void *str, u32 len);
-void flPS2_Clear_Mem16_16A(void *str, u32 len);
-void flPS2_Fill_Mem(void *str, s32 c, u32 len);
-void flPS2_Fill_Mem16_16A(void *str, s64 c, u32 len);
+void flPS2_Mem_move(const void *src, void *dst, size_t len);
+void flPS2_Mem_move16(const void *src, void *dst, size_t len);
+void flPS2_Mem_move16_8A(const void *src, void *dst, size_t len);
+void flPS2_Mem_move16_16A(const void *src, void *dst, size_t len);
+void flPS2_Mem_move32(const void *src, void *dst, size_t len);
+void flPS2_Mem_move32_8A(const void *src, void *dst, size_t len);
+void flPS2_Mem_move32_16A(const void *src, void *dst, size_t len);
+void flPS2_Mem_move64(const void *src, void *dst, size_t len);
+void flPS2_Clear_Mem(void *str, size_t len);
+void flPS2_Clear_Mem16_16A(void *str, size_t len);
+void flPS2_Fill_Mem(void *str, s32 c, size_t len);
+void flPS2_Fill_Mem16_16A(void *str, s64 c, size_t len);
 
 #endif

--- a/include/sf33rd/AcrSDK/ps2/flps2dma.h
+++ b/include/sf33rd/AcrSDK/ps2/flps2dma.h
@@ -14,20 +14,20 @@
 #define DMAret (6 << 28)
 #define DMAend (7 << 28)
 
-u32 flPS2DmaAddEndTag(u32 tag, s32 qwc, s32 irq, s32 /* unused */);
+uintptr_t flPS2DmaAddEndTag(uintptr_t tag, s32 qwc, s32 irq, s32 /* unused */);
 void flPS2DmaInitControl(FLPS2VIF1Control *dma_ptr, u32 queue_size, void *handler);
-s32 flPS2DmaAddQueue2(s32 type, u32 data_adrs, u32 endtag_adrs, FLPS2VIF1Control *dma_ptr);
+s32 flPS2DmaAddQueue2(s32 type, uintptr_t data_adrs, uintptr_t endtag_adrs, FLPS2VIF1Control *dma_ptr);
 s32 flPS2DmaInterrupt(s32 ch);
 void flPS2DmaSend();
 s32 flPS2DmaWait();
 s32 flPS2DmaTerminate();
 u32 flPS2VIF1CalcEndLoadImageSize();
-void flPS2VIF1MakeEndLoadImage(u32 buff_ptr, u32 irq);
+void flPS2VIF1MakeEndLoadImage(uintptr_t buff_ptr, u32 irq);
 u32 flPS2VIF1CalcLoadImageSize(u32 size);
-u32 flPS2VIF1MakeLoadImage(u32 buff_ptr, u32 irq, u32 data_ptr, u32 size, s16 dbp, s16 dbw, s16 dpsm, s16 x, s16 y,
-                           s16 w, s16 h);
-void flPS2StoreImageB(u32 load_ptr, u32 size, s16 dbp, s16 dbw, s16 dpsm, s16 x, s16 y, s16 w, s16 h);
-u32 flPS2DmaAddRefTag(u32 tag, s32 qwc, u32 data_adrs, s32 irq, s32 /* unused */);
-u32 flPS2DmaAddRefeTag(u32 tag, s32 qwc, u32 data_adrs, s32 irq, s32 /* unused */);
+uintptr_t flPS2VIF1MakeLoadImage(uintptr_t buff_ptr, u32 irq, uintptr_t data_ptr, u32 size, s16 dbp, s16 dbw, s16 dpsm,
+                                 s16 x, s16 y, s16 w, s16 h);
+void flPS2StoreImageB(uintptr_t load_ptr, u32 size, s16 dbp, s16 dbw, s16 dpsm, s16 x, s16 y, s16 w, s16 h);
+uintptr_t flPS2DmaAddRefTag(uintptr_t tag, s32 qwc, uintptr_t data_adrs, s32 irq, s32 /* unused */);
+uintptr_t flPS2DmaAddRefeTag(uintptr_t tag, s32 qwc, uintptr_t data_adrs, s32 irq, s32 /* unused */);
 
 #endif

--- a/include/sf33rd/AcrSDK/ps2/flps2etc.h
+++ b/include/sf33rd/AcrSDK/ps2/flps2etc.h
@@ -7,7 +7,7 @@
 void flPS2IopModuleLoad(s8 *fname, s32 args, s8 *argp, s32 type);
 s32 flFileRead(s8 *filename, void *buf, s32 len);
 s32 flFileWrite(s8 *filename, void *buf, s32 len);
-s32 flFileAppend(s8 *filename, void *buf, s32 len);
+s32 flFileAppend(s8 *filename, void *buf, ssize_t len);
 s32 flFileLength(s8 *filename);
 void flMemset(void *dst, u32 pat, s32 size);
 void flMemcpy(void *dst, void *src, s32 size);
@@ -20,7 +20,7 @@ void flPS2ReleaseSystemMemory(u32 handle);
 void *flPS2GetSystemBuffAdrs(u32 handle);
 void flPS2SystemTmpBuffInit();
 void flPS2SystemTmpBuffFlush();
-u32 flPS2GetSystemTmpBuff(s32 len, s32 align);
+uintptr_t flPS2GetSystemTmpBuff(s32 len, s32 align);
 u32 flCreateTextureFromFile(s8 *file, u32 flag);
 
 #endif // FLPS2ETC_H

--- a/include/sf33rd/Source/Common/MemMan.h
+++ b/include/sf33rd/Source/Common/MemMan.h
@@ -6,13 +6,13 @@
 
 void mmSystemInitialize();
 void mmHeapInitialize(_MEMMAN_OBJ *mmobj, u8 *adrs, s32 size, s32 unit, s8 *format);
-u32 mmRoundUp(s32 unit, u32 num);
-u32 mmRoundOff(s32 unit, u32 num);
+uintptr_t mmRoundUp(s32 unit, uintptr_t num);
+uintptr_t mmRoundOff(s32 unit, uintptr_t num);
 void mmDebWriteTag(s8 * /* unused */);
-s32 mmGetRemainder(_MEMMAN_OBJ *mmobj);
-s32 mmGetRemainderMin(_MEMMAN_OBJ *mmobj);
-u8 *mmAlloc(_MEMMAN_OBJ *mmobj, s32 size, s32 flag);
-struct _MEMMAN_CELL *mmAllocSub(_MEMMAN_OBJ *mmobj, s32 size, s32 flag);
+ssize_t mmGetRemainder(_MEMMAN_OBJ *mmobj);
+ssize_t mmGetRemainderMin(_MEMMAN_OBJ *mmobj);
+u8 *mmAlloc(_MEMMAN_OBJ *mmobj, ssize_t size, s32 flag);
+struct _MEMMAN_CELL *mmAllocSub(_MEMMAN_OBJ *mmobj, ssize_t size, s32 flag);
 void mmFree(_MEMMAN_OBJ *mmobj, u8 *adrs);
 
 #endif

--- a/include/sf33rd/Source/Common/PPGFile.h
+++ b/include/sf33rd/Source/Common/PPGFile.h
@@ -15,7 +15,7 @@ s32 ppgWriteQuadWithST_B2(Vertex *pos, u32 col, PPGDataList *tb, s32 tix, s32 ci
 s32 ppgSetupPalChunk(Palette *pch, u8 *adrs, s32 size, s32 ixNum1st, s32 num, s32 /* unused */);
 void ppgRenewDotDataSeqs(Texture *tch, u32 gix, u32 *srcRam, u32 code, u32 size);
 void ppgMakeConvTableTexDC();
-s32 ppgSetupTexChunk_1st(Texture *tch, u8 *adrs, s32 size, s32 ixNum1st, s32 ixNums, s32 ar, s32 arcnt);
+s32 ppgSetupTexChunk_1st(Texture *tch, u8 *adrs, ssize_t size, s32 ixNum1st, s32 ixNums, s32 ar, s32 arcnt);
 s32 ppgSetupTexChunk_2nd(Texture *tch, s32 ixNum);
 s32 ppgSetupTexChunk_3rd(Texture *tch, s32 ixNum, u32 attribute);
 s32 ppgWriteQuadUseTrans(Vertex *pos, u32 col, PPGDataList *tb, s32 tix, s32 cix, s32 flip, s32 pal);

--- a/include/sf33rd/Source/Compress/zlibApp.h
+++ b/include/sf33rd/Source/Compress/zlibApp.h
@@ -4,6 +4,6 @@
 #include "types.h"
 
 void zlib_Initialize(void *tempAdrs, s32 tempSize);
-s32 zlib_Decompress(void *srcBuff, s32 srcSize, void *dstBuff, s32 dstSize);
+ssize_t zlib_Decompress(void *srcBuff, s32 srcSize, void *dstBuff, s32 dstSize);
 
 #endif

--- a/include/sf33rd/Source/Game/RAMCNT.h
+++ b/include/sf33rd/Source/Game/RAMCNT.h
@@ -6,11 +6,11 @@
 
 #define RCKEY_WORK_MAX 64
 
-extern s16 rckeyctr;             // size: 0x2, address: 0x57967C
-extern s16 rckeymin;             // size: 0x2, address: 0x579678
-extern _MEMMAN_OBJ rckey_mmobj;  // size: 0x2C, address: 0x579700
-extern RCKeyWork rckey_work[RCKEY_WORK_MAX]; // size: 0x300, address: 0x5E5600
-extern s16 rckeyque[RCKEY_WORK_MAX];         // size: 0x80, address: 0x579680
+extern s16 rckeyctr;
+extern s16 rckeymin;
+extern _MEMMAN_OBJ rckey_mmobj;
+extern RCKeyWork rckey_work[RCKEY_WORK_MAX];
+extern s16 rckeyque[RCKEY_WORK_MAX];
 
 void disp_ramcnt_free_area();
 void Init_ram_control_work(u8 *adrs, s32 size);
@@ -18,10 +18,10 @@ void Push_ramcnt_key(s16 key);
 void Push_ramcnt_key_original_2(s16 key);
 void Purge_memory_of_kind_of_key(u8 kokey);
 void Set_size_data_ramcnt_key(s16 key, u32 size);
-u32 Get_ramcnt_address(s16 key);
+uintptr_t Get_ramcnt_address(s16 key);
 s16 Search_ramcnt_type(u8 kokey);
-s16 Pull_ramcnt_key(u32 memreq, u8 kokey, u8 group, u8 frre);
-u32 Get_size_data_ramcnt_key(s16 key);
+s16 Pull_ramcnt_key(size_t memreq, u8 kokey, u8 group, u8 frre);
+size_t Get_size_data_ramcnt_key(s16 key);
 s32 Test_ramcnt_key(s16 key);
 void Push_ramcnt_key_original(s16 key);
 

--- a/include/sf33rd/Source/PS2/mc/knjsub.h
+++ b/include/sf33rd/Source/PS2/mc/knjsub.h
@@ -3,7 +3,7 @@
 
 #include "types.h"
 
-void KnjInit(u32 type, u32 adrs, u32 disp_max, u32 top_dbp);
+void KnjInit(u32 type, uintptr_t adrs, u32 disp_max, u32 top_dbp);
 void KnjFinish();
 void KnjSetSize(s32 dispw, s32 disph);
 void KnjLocate(s32 x, s32 y);

--- a/include/sf33rd/Source/PS2/mc/mcsub.h
+++ b/include/sf33rd/Source/PS2/mc/mcsub.h
@@ -5,10 +5,10 @@
 
 typedef struct _file {
     // total size: 0x10
-    s32 flag; // offset 0x0, size 0x4
-    s8 *name; // offset 0x4, size 0x4
-    s32 bufs; // offset 0x8, size 0x4
-    s32 size; // offset 0xC, size 0x4
+    s32 flag;      // offset 0x0, size 0x4
+    s8 *name;      // offset 0x4, size 0x4
+    intptr_t bufs; // offset 0x8, size 0x4
+    s32 size;      // offset 0xC, size 0x4
 };
 
 typedef struct _memcard_file {

--- a/include/sf33rd/Source/PS2/mc/mcsub.h
+++ b/include/sf33rd/Source/PS2/mc/mcsub.h
@@ -9,7 +9,7 @@ typedef struct _file {
     s8 *name;      // offset 0x4, size 0x4
     intptr_t bufs; // offset 0x8, size 0x4
     s32 size;      // offset 0xC, size 0x4
-};
+} _file;
 
 typedef struct _memcard_file {
     // total size: 0x74

--- a/include/structs.h
+++ b/include/structs.h
@@ -754,62 +754,62 @@ typedef struct {
 
 typedef struct {
     // total size: 0x470
-    u32 VideoMode;              // offset 0x0, size 0x4
-    u32 InterlaceMode;          // offset 0x4, size 0x4
-    u32 DisplayMode;            // offset 0x8, size 0x4
-    s32 DispWidth;              // offset 0xC, size 0x4
-    s32 DispHeight;             // offset 0x10, size 0x4
-    u32 MAGH;                   // offset 0x14, size 0x4
-    u32 FrameBitDepth;          // offset 0x18, size 0x4
-    u32 FrameBuffForm;          // offset 0x1C, size 0x4
-    u32 FrameBuffPageX;         // offset 0x20, size 0x4
-    u32 FrameBuffPageY;         // offset 0x24, size 0x4
-    u32 FrameBuffAdrs0;         // offset 0x28, size 0x4
-    u32 FrameBuffAdrs1;         // offset 0x2C, size 0x4
-    u32 ZBuffBitDepth;          // offset 0x30, size 0x4
-    u32 ZBuffForm;              // offset 0x34, size 0x4
-    u32 ZBuffPageX;             // offset 0x38, size 0x4
-    u32 ZBuffPageY;             // offset 0x3C, size 0x4
-    u32 ZBuffAdrs;              // offset 0x40, size 0x4
-    f32 ZBuffMax;               // offset 0x44, size 0x4
-    u32 TextureStartAdrs;       // offset 0x48, size 0x4
-    s32 Oddeven;                // offset 0x4C, size 0x4
-    s32 Dbi;                    // offset 0x50, size 0x4
-    s32 FrameCount;             // offset 0x54, size 0x4
-    s32 FrameCountNext;         // offset 0x58, size 0x4
-    s32 Irq_count;              // offset 0x5C, size 0x4
-    s32 Db_change_enable;       // offset 0x60, size 0x4
-    s8 pad64[0xC];              // offset 0x64, size 0xC
-    sceGsDBuffDc Db;            // offset 0x70, size 0x330
-    u32 FrameClearColor;        // offset 0x3A0, size 0x4
-    s32 D2dOffsetX;             // offset 0x3A4, size 0x4
-    s32 D2dOffsetY;             // offset 0x3A8, size 0x4
-    s32 ScreenOffsetX;          // offset 0x3AC, size 0x4
-    s32 ScreenOffsetY;          // offset 0x3B0, size 0x4
-    s32 ScreenDispX;            // offset 0x3B4, size 0x4
-    s32 ScreenDispY;            // offset 0x3B8, size 0x4
-    s32 ScreenAdjustX;          // offset 0x3BC, size 0x4
-    s32 ScreenAdjustY;          // offset 0x3C0, size 0x4
-    sceDmaChan *DmaChan[10];    // offset 0x3C4, size 0x28
-    s32 NowVu1Code;             // offset 0x3EC, size 0x4
-    s32 NowVu1Size;             // offset 0x3F0, size 0x4
-    s32 DrawDisable;            // offset 0x3F4, size 0x4
-    u32 system_memory_start;    // offset 0x3F8, size 0x4
-    s32 system_memory_size;     // offset 0x3FC, size 0x4
-    u32 SystemStatus;           // offset 0x400, size 0x4
-    s32 SystemIndex;            // offset 0x404, size 0x4
-    u32 SystemTmpBuffStartAdrs; // offset 0x408, size 0x4
-    u32 SystemTmpBuffEndAdrs;   // offset 0x40C, size 0x4
-    u32 SystemTmpBuffNow;       // offset 0x410, size 0x4
-    u32 SystemTmpBuffHandle[2]; // offset 0x414, size 0x8
-    u64 RenderTESTStatus1;      // offset 0x420, size 0x4
-    u64 RenderTESTStatus2;      // offset 0x428, size 0x4
-    u64 RenderZBUFStatus1;      // offset 0x430, size 0x4
-    u64 RenderZBUFStatus2;      // offset 0x438, size 0x4
-    u64 RenderSCISSORStatus1;   // offset 0x440, size 0x4
-    s32 RenderSCISSORValue1[4]; // offset 0x448, size 0x10
-    u64 RenderSCISSORStatus2;   // offset 0x458, size 0x4
-    s32 RenderSCISSORValue2[4]; // offset 0x460, size 0x10
+    u32 VideoMode;                    // offset 0x0, size 0x4
+    u32 InterlaceMode;                // offset 0x4, size 0x4
+    u32 DisplayMode;                  // offset 0x8, size 0x4
+    s32 DispWidth;                    // offset 0xC, size 0x4
+    s32 DispHeight;                   // offset 0x10, size 0x4
+    u32 MAGH;                         // offset 0x14, size 0x4
+    u32 FrameBitDepth;                // offset 0x18, size 0x4
+    u32 FrameBuffForm;                // offset 0x1C, size 0x4
+    u32 FrameBuffPageX;               // offset 0x20, size 0x4
+    u32 FrameBuffPageY;               // offset 0x24, size 0x4
+    u32 FrameBuffAdrs0;               // offset 0x28, size 0x4
+    u32 FrameBuffAdrs1;               // offset 0x2C, size 0x4
+    u32 ZBuffBitDepth;                // offset 0x30, size 0x4
+    u32 ZBuffForm;                    // offset 0x34, size 0x4
+    u32 ZBuffPageX;                   // offset 0x38, size 0x4
+    u32 ZBuffPageY;                   // offset 0x3C, size 0x4
+    u32 ZBuffAdrs;                    // offset 0x40, size 0x4
+    f32 ZBuffMax;                     // offset 0x44, size 0x4
+    u32 TextureStartAdrs;             // offset 0x48, size 0x4
+    s32 Oddeven;                      // offset 0x4C, size 0x4
+    s32 Dbi;                          // offset 0x50, size 0x4
+    s32 FrameCount;                   // offset 0x54, size 0x4
+    s32 FrameCountNext;               // offset 0x58, size 0x4
+    s32 Irq_count;                    // offset 0x5C, size 0x4
+    s32 Db_change_enable;             // offset 0x60, size 0x4
+    s8 pad64[0xC];                    // offset 0x64, size 0xC
+    sceGsDBuffDc Db;                  // offset 0x70, size 0x330
+    u32 FrameClearColor;              // offset 0x3A0, size 0x4
+    s32 D2dOffsetX;                   // offset 0x3A4, size 0x4
+    s32 D2dOffsetY;                   // offset 0x3A8, size 0x4
+    s32 ScreenOffsetX;                // offset 0x3AC, size 0x4
+    s32 ScreenOffsetY;                // offset 0x3B0, size 0x4
+    s32 ScreenDispX;                  // offset 0x3B4, size 0x4
+    s32 ScreenDispY;                  // offset 0x3B8, size 0x4
+    s32 ScreenAdjustX;                // offset 0x3BC, size 0x4
+    s32 ScreenAdjustY;                // offset 0x3C0, size 0x4
+    sceDmaChan *DmaChan[10];          // offset 0x3C4, size 0x28
+    s32 NowVu1Code;                   // offset 0x3EC, size 0x4
+    s32 NowVu1Size;                   // offset 0x3F0, size 0x4
+    s32 DrawDisable;                  // offset 0x3F4, size 0x4
+    uintptr_t system_memory_start;    // offset 0x3F8, size 0x4
+    s32 system_memory_size;           // offset 0x3FC, size 0x4
+    u32 SystemStatus;                 // offset 0x400, size 0x4
+    s32 SystemIndex;                  // offset 0x404, size 0x4
+    uintptr_t SystemTmpBuffStartAdrs; // offset 0x408, size 0x4
+    uintptr_t SystemTmpBuffEndAdrs;   // offset 0x40C, size 0x4
+    uintptr_t SystemTmpBuffNow;       // offset 0x410, size 0x4
+    u32 SystemTmpBuffHandle[2];       // offset 0x414, size 0x8
+    u64 RenderTESTStatus1;            // offset 0x420, size 0x4
+    u64 RenderTESTStatus2;            // offset 0x428, size 0x4
+    u64 RenderZBUFStatus1;            // offset 0x430, size 0x4
+    u64 RenderZBUFStatus2;            // offset 0x438, size 0x4
+    u64 RenderSCISSORStatus1;         // offset 0x440, size 0x4
+    s32 RenderSCISSORValue1[4];       // offset 0x448, size 0x10
+    u64 RenderSCISSORStatus2;         // offset 0x458, size 0x4
+    s32 RenderSCISSORValue2[4];       // offset 0x460, size 0x10
 } FLPS2State;
 
 typedef struct {
@@ -823,8 +823,8 @@ typedef struct {
     u32 queue_ptr1[2];          // offset 0x24, size 0x8
     u32 now_adrs;               // offset 0x2C, size 0x4
     u32 dma_normal_mode_status; // offset 0x30, size 0x4
-    u32 old_queue_data;         // offset 0x34, size 0x4
-    u32 old_endtag;             // offset 0x38, size 0x4
+    uintptr_t old_queue_data;   // offset 0x34, size 0x4
+    uintptr_t old_endtag;       // offset 0x38, size 0x4
 } FLPS2VIF1Control;
 
 typedef union {
@@ -997,17 +997,17 @@ struct _MEMMAN_CELL {
     // total size: 0xC
     struct _MEMMAN_CELL *prev; // offset 0x0, size 0x4
     struct _MEMMAN_CELL *next; // offset 0x4, size 0x4
-    s32 size;                  // offset 0x8, size 0x4
+    ssize_t size;              // offset 0x8, size 0x4
 };
 
 typedef struct {
     // total size: 0x2C
     u8 *memHead;                   // offset 0x0, size 0x4
-    s32 memSize;                   // offset 0x4, size 0x4
+    ssize_t memSize;               // offset 0x4, size 0x4
     u32 ownNumber;                 // offset 0x8, size 0x4
     s32 ownUnit;                   // offset 0xC, size 0x4
-    s32 remainder;                 // offset 0x10, size 0x4
-    s32 remainderMin;              // offset 0x14, size 0x4
+    ssize_t remainder;             // offset 0x10, size 0x4
+    ssize_t remainderMin;          // offset 0x14, size 0x4
     struct _MEMMAN_CELL *cell_1st; // offset 0x18, size 0x4
     struct _MEMMAN_CELL *cell_fin; // offset 0x1C, size 0x4
     u8 *oriHead;                   // offset 0x20, size 0x4
@@ -1534,11 +1534,11 @@ typedef union {
 
 typedef struct {
     // total size: 0xC
-    s8 ok;             // offset 0x0, size 0x1
-    s8 type;           // offset 0x1, size 0x1
-    s16 key;           // offset 0x2, size 0x2
-    u32 texture_table; // offset 0x4, size 0x4
-    u32 trans_table;   // offset 0x8, size 0x4
+    s8 ok;                   // offset 0x0, size 0x1
+    s8 type;                 // offset 0x1, size 0x1
+    s16 key;                 // offset 0x2, size 0x2
+    uintptr_t texture_table; // offset 0x4, size 0x4
+    uintptr_t trans_table;   // offset 0x8, size 0x4
 } TEX_GRP_LD;
 
 typedef struct {
@@ -1620,8 +1620,8 @@ typedef struct {
 
 typedef struct {
     // total size: 0xC
-    u32 adr;        // offset 0x0, size 0x4
-    u32 size;       // offset 0x4, size 0x4
+    uintptr_t adr;  // offset 0x0, size 0x4
+    size_t size;    // offset 0x4, size 0x4
     u8 search_type; // offset 0x8, size 0x1
     u8 group_num;   // offset 0x9, size 0x1
     u8 type;        // offset 0xA, size 0x1
@@ -1697,7 +1697,7 @@ typedef struct {
     u16 accnum;            // offset 0x12, size 0x2
     u32 *offset;           // offset 0x14, size 0x4
     u8 *srcAdrs;           // offset 0x18, size 0x4
-    u32 srcSize;           // offset 0x1C, size 0x4
+    size_t srcSize;        // offset 0x1C, size 0x4
 } Texture;
 
 typedef struct {
@@ -2035,8 +2035,8 @@ typedef struct {
 
 typedef struct {
     // total size: 0x1C
-    u32 parent;         // offset 0x0, size 0x4
-    u32 child;          // offset 0x4, size 0x4
+    uintptr_t parent;   // offset 0x0, size 0x4
+    uintptr_t child;    // offset 0x4, size 0x4
     FLTexture *tex_ptr; // offset 0x8, size 0x4
     u32 desc;           // offset 0xC, size 0x4
     u32 flag;           // offset 0x10, size 0x4

--- a/include/types.h
+++ b/include/types.h
@@ -29,9 +29,20 @@ typedef unsigned long long u64;
 typedef float f32;
 typedef double f64;
 
+typedef s32 intptr_t;
+typedef u32 uintptr_t;
+typedef s32 ptrdiff_t;
+
+// Old code insists on treating strlen's return type as a signed integer
+typedef s32 strlen_t;
+
+typedef s32 ssize_t;
+
 #else
 
+#include <stddef.h>
 #include <stdint.h>
+#include <sys/types.h>
 
 typedef int8_t s8;
 typedef int16_t s16;
@@ -44,6 +55,8 @@ typedef uint64_t u64;
 
 typedef float f32;
 typedef double f64;
+
+typedef size_t strlen_t;
 
 // SCE types
 

--- a/src/anniversary/cri/libadxe/adx_bsc.c
+++ b/src/anniversary/cri/libadxe/adx_bsc.c
@@ -397,7 +397,7 @@ INCLUDE_ASM("asm/anniversary/nonmatchings/cri/libadxe/adx_bsc", ADXB_SetExtStrin
 INCLUDE_ASM("asm/anniversary/nonmatchings/cri/libadxe/adx_bsc", ADXB_SetDefExtString);
 
 Sint32 adxb_get_key(ADXB adxb, Uint8 arg1, Uint8 arg2, Sint32 arg3, Sint16 *arg4, Sint16 *arg5, Sint16 *arg6) {
-    Char8 sp[8];
+    Char8 sp[9];
 
     if (arg1 >= 4) {
         if (arg2 >= 0x10) {

--- a/src/anniversary/cri/libadxe/adx_bsc.c
+++ b/src/anniversary/cri/libadxe/adx_bsc.c
@@ -79,22 +79,25 @@ void ADXB_Finish() {
 INCLUDE_ASM("asm/anniversary/nonmatchings/cri/libadxe/adx_bsc", ADXB_Finish);
 #endif
 
-Sint32 adxb_DefGetWr(void *object, Sint32 *arg1, Sint32 *arg2, Sint32 *arg3) {
+void *adxb_DefGetWr(void *object, Sint32 *arg1, Sint32 *arg2, Sint32 *arg3) {
     ADXB adxb = (ADXB)object;
-    Sint32 ret = adxb->unk3C;
+    void *ret = adxb->unk3C;
+
     *arg1 = adxb->unk8C;
     *arg2 = adxb->unk40 - adxb->unk8C;
     *arg3 = adxb->total_samples - adxb->unk88;
+
     return ret;
 }
 
 void adxb_DefAddWr(void *object, Sint32 arg1, Sint32 arg2) {
     ADXB adxb = (ADXB)object;
+
     adxb->unk8C += arg2;
     adxb->unk88 += arg2;
 }
 
-ADXB ADXB_Create(Sint32 arg0, Sint32 arg1, Sint32 arg2, Sint32 arg3) {
+ADXB ADXB_Create(Sint32 arg0, void *arg1, Sint32 arg2, Sint32 arg3) {
     ADXB adxb;
     ADXB chk_adxb;
     ADXPD adxpd;
@@ -289,14 +292,14 @@ Sint32 ADXB_DecodeHeader(ADXB adxb, void *header, Sint32 len) {
     return -1;
 }
 
-void ADXB_EntryGetWrFunc(ADXB adxb, Sint32 (*get_wr)(void *, Sint32 *, Sint32 *, Sint32 *), void *object) {
+void ADXB_EntryGetWrFunc(ADXB adxb, void *(*get_wr)(void *, ptrdiff_t *, Sint32 *, Sint32 *), void *object) {
     adxb->get_wr = get_wr;
     adxb->object = object;
 }
 
 INCLUDE_ASM("asm/anniversary/nonmatchings/cri/libadxe/adx_bsc", ADXB_EntryAddWrFunc);
 
-Sint32 ADXB_GetPcmBuf(ADXB adxb) {
+void *ADXB_GetPcmBuf(ADXB adxb) {
     return adxb->unk3C;
 }
 

--- a/src/anniversary/cri/libadxe/adx_errs.c
+++ b/src/anniversary/cri/libadxe/adx_errs.c
@@ -52,9 +52,9 @@ void ADXERR_CallErrFunc2(s8 *arg0, s8 *arg1) {
 
 #pragma divbyzerocheck
 
-void ADXERR_ItoA(s32 value, s8 *str, s32 base) {
+void ADXERR_ItoA(s32 value, s8 *str, strlen_t base) {
     s32 i;
-    s32 len;
+    strlen_t len;
 
     for (i = 0; i < 32; i++) {
         str[i] = value % 10;

--- a/src/anniversary/cri/libadxe/adx_fs.c
+++ b/src/anniversary/cri/libadxe/adx_fs.c
@@ -36,23 +36,23 @@ Sint32 ADXF_CALC_BYTE2SCT(Sint32 bytes) {
     return result;
 }
 
-void adxf_SetCmdHstry(Sint32 cmdid, Sint32 fg, Sint32 ptid, Sint32 flid, Sint32 type) {
+void adxf_SetCmdHstry(Sint32 cmdid, Sint32 fg, intptr_t prm_0, intptr_t prm_1, intptr_t prm_2) {
     ADXF_CMD_HSTRY *cmd_hstry;
 
     adxf_hstry_no %= ADXF_CMD_HSTRY_MAX;
     cmd_hstry = &adxf_cmd_hstry[adxf_hstry_no];
 
     if (fg == 0) {
-        adxf_cmd_ncall[cmdid]++;
+        adxf_cmd_ncall[cmdid] += 1;
     }
 
-    adxf_hstry_no++;
+    adxf_hstry_no += 1;
     cmd_hstry->cmdid = cmdid;
     cmd_hstry->fg = fg;
     cmd_hstry->ncall = adxf_cmd_ncall[cmdid];
-    cmd_hstry->prm[0] = ptid;
-    cmd_hstry->prm[1] = flid;
-    cmd_hstry->prm[2] = type;
+    cmd_hstry->prm[0] = prm_0;
+    cmd_hstry->prm[1] = prm_1;
+    cmd_hstry->prm[2] = prm_2;
 }
 
 void adxf_wait_1ms() {
@@ -82,7 +82,7 @@ INCLUDE_ASM("asm/anniversary/nonmatchings/cri/libadxe/adx_fs", ADXF_LoadPartitio
 INCLUDE_ASM("asm/anniversary/nonmatchings/cri/libadxe/adx_fs", ADXF_LoadPartitionEx);
 
 Sint32 ADXF_LoadPartitionNw(Sint32 ptid, Char8 *fname, void *dir, void *ptinfo) {
-    void *tmpbuf = (void *)(((Uint32)&adxf_ldpt_work + 0x40) & ~0x3F);
+    void *tmpbuf = (void *)(((uintptr_t)&adxf_ldpt_work + 0x40) & ~0x3F);
     return ADXF_LoadPtNwEx(ptid, fname, dir, ptinfo, tmpbuf, 0x800);
 }
 
@@ -314,7 +314,7 @@ Sint32 adxf_SetFileInfoEx(ADXF adxf, Char8 *fname, void *dir) {
 ADXF ADXF_Open(Char8 *fname, void *atr) {
     ADXF adxf;
 
-    adxf_SetCmdHstry(ADXF_CMD_OPEN, 0, (Sint32)fname, (Sint32)atr, -1);
+    adxf_SetCmdHstry(ADXF_CMD_OPEN, 0, (intptr_t)fname, (intptr_t)atr, -1);
     adxf = adxf_CreateAdxFs();
 
     if (adxf != NULL) {
@@ -324,7 +324,7 @@ ADXF ADXF_Open(Char8 *fname, void *atr) {
         }
     }
 
-    adxf_SetCmdHstry(ADXF_CMD_OPEN, 1, (Sint32)fname, (Sint32)atr, -1);
+    adxf_SetCmdHstry(ADXF_CMD_OPEN, 1, (intptr_t)fname, (intptr_t)atr, -1);
     return adxf;
 }
 
@@ -360,7 +360,7 @@ Sint32 adxf_SetAfsFileInfo(ADX_FS *adxf, Sint32 ptid, Sint32 flid) {
 ADXF ADXF_OpenAfs(Sint32 ptid, Sint32 flid) {
     ADXF adxf;
 
-    adxf_SetCmdHstry(ADXF_CMD_OPEN_AFS, 0, ptid, flid, -1);
+    adxf_SetCmdHstry(ADXF_CMD_OPEN_AFS, 0, (intptr_t)ptid, (intptr_t)flid, -1);
     adxf = adxf_CreateAdxFs();
 
     if ((adxf != NULL) && (adxf_SetAfsFileInfo(adxf, ptid, flid) < 0)) {
@@ -368,7 +368,7 @@ ADXF ADXF_OpenAfs(Sint32 ptid, Sint32 flid) {
         adxf = NULL;
     }
 
-    adxf_SetCmdHstry(ADXF_CMD_OPEN_AFS, 1, ptid, flid, -1);
+    adxf_SetCmdHstry(ADXF_CMD_OPEN_AFS, 1, (intptr_t)ptid, (intptr_t)flid, -1);
     return adxf;
 }
 
@@ -391,7 +391,7 @@ void adxf_CloseSjStm(ADXF adxf) {
 void ADXF_Close(ADXF adxf) {
     ADXSTM stm;
 
-    adxf_SetCmdHstry(ADXF_CMD_CLOSE, 0, (Sint32)adxf, -1, -1);
+    adxf_SetCmdHstry(ADXF_CMD_CLOSE, 0, (intptr_t)adxf, -1, -1);
 
     if (adxf == NULL) {
         return;
@@ -411,7 +411,7 @@ void ADXF_Close(ADXF adxf) {
     }
 
     memset(adxf, 0, sizeof(ADX_FS));
-    adxf_SetCmdHstry(ADXF_CMD_CLOSE, 1, (Sint32)adxf, -1, -1);
+    adxf_SetCmdHstry(ADXF_CMD_CLOSE, 1, (intptr_t)adxf, -1, -1);
 }
 
 void ADXF_CloseAll() {
@@ -475,7 +475,7 @@ Sint32 ADXF_ReadNw32(ADXF adxf, Sint32 nsct, void *buf) {
     Sint32 bsize;
     Sint32 temp_v0_2;
 
-    adxf_SetCmdHstry(ADXF_CMD_READ_NW32, 0, adxf, nsct, buf);
+    adxf_SetCmdHstry(ADXF_CMD_READ_NW32, 0, (intptr_t)adxf, (intptr_t)nsct, buf);
 
     if (adxf == 0) {
         ADXERR_CallErrFunc1("E9040816:'adxf' is NULL.(ADXF_ReadNw32)");
@@ -533,12 +533,12 @@ Sint32 ADXF_ReadNw32(ADXF adxf, Sint32 nsct, void *buf) {
     }
 
     adxf->sjflag = 0;
-    adxf_SetCmdHstry(ADXF_CMD_READ_NW32, 1, adxf, nsct, buf);
+    adxf_SetCmdHstry(ADXF_CMD_READ_NW32, 1, (intptr_t)adxf, (intptr_t)nsct, buf);
     return temp_v0_2;
 }
 
 Sint32 ADXF_ReadNw(ADXF adxf, Sint32 nsct, void *buf) {
-    if ((Sint32)buf & 0x3F) {
+    if ((uintptr_t)buf & 0x3F) {
         ADXERR_CallErrFunc1("E0120401:'buf' isn't 64byte alignment.(ADXF_ReadNw)");
         return ADXF_ERR_PRM;
     }
@@ -549,7 +549,7 @@ Sint32 ADXF_ReadNw(ADXF adxf, Sint32 nsct, void *buf) {
 Sint32 ADXF_Stop(ADXF adxf) {
     ADXSTM stm;
 
-    adxf_SetCmdHstry(ADXF_CMD_STOP, 0, adxf, -1, -1);
+    adxf_SetCmdHstry(ADXF_CMD_STOP, 0, (intptr_t)adxf, -1, -1);
 
     if (adxf == NULL) {
         ADXERR_CallErrFunc1("E9040822:'adxf' is NULL.(ADXF_Stop)");
@@ -578,7 +578,7 @@ Sint32 ADXF_Stop(ADXF adxf) {
         adxf_CloseSjStm(adxf);
         adxf->stat = 1;
         ADXCRS_Unlock();
-        adxf_SetCmdHstry(ADXF_CMD_STOP, 1, adxf, -1, -1);
+        adxf_SetCmdHstry(ADXF_CMD_STOP, 1, (intptr_t)adxf, -1, -1);
         break;
     }
 
@@ -586,7 +586,7 @@ Sint32 ADXF_Stop(ADXF adxf) {
 }
 
 Sint32 ADXF_StopNw(ADXF adxf) {
-    adxf_SetCmdHstry(ADXF_CMD_STOP_NW, 0, (Sint32)adxf, -1, -1);
+    adxf_SetCmdHstry(ADXF_CMD_STOP_NW, 0, (intptr_t)adxf, -1, -1);
 
     if (adxf == NULL) {
         ADXERR_CallErrFunc1("E2092301:'adxf' is NULL.(ADXF_StopNw)");
@@ -610,7 +610,7 @@ Sint32 ADXF_StopNw(ADXF adxf) {
 
         ADXSTM_StopNw(adxf->stm);
         adxf->stopnw_flg = 1;
-        adxf_SetCmdHstry(ADXF_CMD_STOP_NW, 1, (Sint32)adxf, -1, -1);
+        adxf_SetCmdHstry(ADXF_CMD_STOP_NW, 1, (intptr_t)adxf, -1, -1);
         break;
     }
 

--- a/src/anniversary/cri/libadxe/adx_sjd.c
+++ b/src/anniversary/cri/libadxe/adx_sjd.c
@@ -15,7 +15,7 @@ void (*pl2setsfreqfunc)(ADXB, Sint32) = NULL;
 ADXSJD_OBJ adxsjd_obj[ADXSJD_MAX_OBJ] = { 0 };
 
 // forward decls
-Sint32 adxsjd_get_wr(ADXSJD sjd, Sint32 *arg1, Sint32 *arg2, Sint32 *arg3);
+void *adxsjd_get_wr(ADXSJD sjd, ptrdiff_t *arg1, Sint32 *arg2, Sint32 *arg3);
 
 void ADXSJD_Init() {
     ADXB_Init();
@@ -41,7 +41,7 @@ void adxsjd_clear(ADXSJD sjd) {
 ADXSJD ADXSJD_Create(SJ sj, Sint32 maxnch, SJ *sjo) {
     ADXSJD sjd;
     SJ out;
-    Sint32 buf_ptr;
+    void *buf_ptr;
     Sint32 i;
     Sint32 y;
     Sint32 buf_size;
@@ -198,7 +198,7 @@ void adxsjd_decode_prep(ADXSJD sjd) {
     sjd->state = state;
 }
 
-Sint32 adxsjd_get_wr(ADXSJD sjd, Sint32 *arg1, Sint32 *arg2, Sint32 *arg3) {
+void *adxsjd_get_wr(ADXSJD sjd, ptrdiff_t *arg1, Sint32 *arg2, Sint32 *arg3) {
     Sint32 temp_v0_3;
     Sint32 i;
     Sint32 var_v0;
@@ -215,7 +215,7 @@ Sint32 adxsjd_get_wr(ADXSJD sjd, Sint32 *arg1, Sint32 *arg2, Sint32 *arg3) {
         SJ_GetChunk(sjo[i], 0, 0x4000, &chunk_p[i]);
     }
 
-    *arg1 = (Sint32)(sjd->chunks[0].data - SJRBF_GetBufPtr(first_out)) / 2;
+    *arg1 = ((void *)sjd->chunks[0].data - SJRBF_GetBufPtr(first_out)) / 2;
 
     a0 = sjd->unk38;
     temp_v0_3 = sjd->chunks[0].len / 2;

--- a/src/anniversary/cri/libadxe/adx_stmc.c
+++ b/src/anniversary/cri/libadxe/adx_stmc.c
@@ -393,7 +393,7 @@ void adxstmf_stat_exec(ADXSTM stm) {
 }
 
 void ADXSTMF_ExecHndl(ADXSTM stm) {
-    Sint32 cvfs;
+    void *cvfs;
     Sint32 cur_pos;
 
     if (stm->read_flg == 0) {

--- a/src/anniversary/cri/libadxe/adx_tlk.c
+++ b/src/anniversary/cri/libadxe/adx_tlk.c
@@ -48,12 +48,12 @@ ADXT ADXT_Create(Sint32 maxnch, void *work, Sint32 worksize) {
     Sint32 _maxnch;
     Sint32 i;
     Sint32 ix;
-    Sint32 aligned_work;
-    Sint32 size;
-    Sint32 ibuf_len;
+    intptr_t aligned_work;
+    ptrdiff_t size;
+    ptrdiff_t ibuf_len;
 
-    aligned_work = ((Uint32)work + 0x40 - 1) & ~(0x40 - 1);
-    size = worksize - (aligned_work - (Uint32)work);
+    aligned_work = ((uintptr_t)work + 0x40 - 1) & ~(0x40 - 1);
+    size = worksize - (aligned_work - (uintptr_t)work);
 
     if ((maxnch < 0) || (work == NULL) || (worksize < 0)) {
         ADXERR_CallErrFunc1("E02080804 ADXT_Create: parameter error");
@@ -82,7 +82,7 @@ ADXT ADXT_Create(Sint32 maxnch, void *work, Sint32 worksize) {
     adxt->obufdist = ADXT_OBUF_DIST;
     adxt->ibufxlen = ADXT_IBUF_XLEN;
     ibuf_len = size - ADXT_CALC_OBUFSIZE(_maxnch) - 0x124;
-    adxt->ibuflen = ibuf_len / 0x800 * 0x800;
+    adxt->ibuflen = (Sint32)(ibuf_len / 0x800 * 0x800);
 
     adxt->sji = NULL;
     adxt->unkB0 = adxt->ibuf + (adxt->ibuflen + adxt->ibufxlen);

--- a/src/anniversary/cri/libadxe/cri_cvfs.c
+++ b/src/anniversary/cri/libadxe/cri_cvfs.c
@@ -45,7 +45,7 @@ void getDefDev(Char8 *arg0);
 void addDevName(const Char8 *device_name, Char8 *out);
 CVFSDevice *getDevice(const Char8 *name);
 CVFSDevice *addDevice(const Char8 *device_name, CVFSDevice *(*device_provider)());
-Sint32 isExistDev(const Char8 *, Sint32);
+Sint32 isExistDev(const Char8 *, strlen_t);
 void toUpperStr(Char8 *str);
 
 void cvFsCallUsrErrFn(void *object, const Char8 *msg, Sint32 arg2) {
@@ -116,7 +116,7 @@ CVFSDevice *addDevice(const Char8 *device_name, CVFSDevice *(*device_provider)()
 }
 
 CVFSDevice *getDevice(const Char8 *name) {
-    Sint32 len = strlen(name);
+    strlen_t len = strlen(name);
     Uint32 i;
 
     for (i = 0; i < CVFS_DEVICE_MAX; i++) {
@@ -129,7 +129,7 @@ CVFSDevice *getDevice(const Char8 *name) {
 }
 
 void toUpperStr(Char8 *str) {
-    Uint32 len = strlen(str);
+    size_t len = strlen(str);
     Sint32 i;
 
     for (i = 0; i < len + 1; i++) {
@@ -143,7 +143,7 @@ INCLUDE_RODATA("asm/anniversary/nonmatchings/cri/libadxe/cri_cvfs", D_0055BE38);
 INCLUDE_ASM("asm/anniversary/nonmatchings/cri/libadxe/cri_cvfs", cvFsDelDev);
 
 void cvFsSetDefDev(const Char8 *device_name) {
-    Sint32 device_name_len;
+    strlen_t device_name_len;
 
     if (device_name == NULL) {
         cvFsError("cvFsSetDefDev #1:illegal device name");
@@ -167,7 +167,7 @@ void cvFsSetDefDev(const Char8 *device_name) {
     cvFsError("cvFsSetDefDev #2:unknown device name");
 }
 
-Sint32 isExistDev(const Char8 *device_name, Sint32 device_name_length) {
+Sint32 isExistDev(const Char8 *device_name, strlen_t device_name_length) {
     Sint32 i;
 
     for (i = 0; i < CVFS_DEVICE_MAX; i++) {
@@ -331,10 +331,10 @@ void getDevName(Char8 *filename, Char8 *device_name, const Char8 *full_path) {
 }
 
 void getDefDev(Char8 *arg0) {
-    Sint32 len = strlen(D_006BDDA8);
+    strlen_t len = strlen(D_006BDDA8);
 
-    if (*D_006BDDA8 == 0) {
-        *arg0 = 0;
+    if (D_006BDDA8[0] == '\0') {
+        arg0[0] = '\0';
         return;
     }
 

--- a/src/anniversary/cri/libadxe/cri_srd.c
+++ b/src/anniversary/cri/libadxe/cri_srd.c
@@ -345,7 +345,7 @@ void srd_exec_hst(SRD srd) {
 
         if (offset < 0) {
             srd->stat = 9;
-            srd->unk34 = offset;
+            srd->unk34 = (Sint32)offset;
         }
 
         SRD_SetHistory(0x2100);
@@ -357,7 +357,7 @@ void srd_exec_hst(SRD srd) {
             srd_debug_rdbg_cnt += 1;
         } else {
             srd->stat = 9;
-            srd->unk34 = offset;
+            srd->unk34 = (Sint32)offset;
         }
 
         break;
@@ -510,7 +510,7 @@ Sint64 SRD_SceLseek(Sint32 fd, Sint64 offset, Sint32 whence) {
             scePrintf("SRD: sceLseek64 error = %d\r\n", ofst);
         }
     } else {
-        ofst = sceLseek(fd, offset, whence);
+        ofst = sceLseek(fd, (Sint32)offset, whence);
 
         if (ofst < 0) {
             scePrintf("SRD: sceLseek error = %d\r\n", ofst);

--- a/src/anniversary/cri/libadxe/dtr.c
+++ b/src/anniversary/cri/libadxe/dtr.c
@@ -84,7 +84,7 @@ void DTR_ExecHndl(DTR dtr) {
         }
     }
 
-    if ((u32)cks.data & 0x3F) {
+    if ((uintptr_t)cks.data & 0x3F) {
         scePrintf("DTR_ExecHndl: Internal Error cks.data\n");
         scePrintf("cks.data=%08x, ckd.data=%08x, cks.len=%d\n", cks.data, ckd.data, cks.len);
 
@@ -93,7 +93,7 @@ void DTR_ExecHndl(DTR dtr) {
         }
     }
 
-    if ((u32)ckd.data & 0x3F) {
+    if ((uintptr_t)ckd.data & 0x3F) {
         scePrintf("DTR_ExecHndl: Internal Error ckd.data\n");
         scePrintf("cks.data=%08x, ckd.data=%08x, cks.len=%d\n", cks.data, ckd.data, cks.len);
 
@@ -103,8 +103,8 @@ void DTR_ExecHndl(DTR dtr) {
     }
 
     SyncDCache(cks.data, cks.data + cks.len - 1);
-    dtr->dma_data.data = (u32)cks.data & 0x0FFFFFFF;
-    dtr->dma_data.addr = (u32)ckd.data;
+    dtr->dma_data.data = (u32)((uintptr_t)cks.data & 0x0FFFFFFF);
+    dtr->dma_data.addr = (u32)(uintptr_t)ckd.data;
     dtr->dma_data.size = cks.len;
     dtr->dma_data.mode = 0;
     dtr->unk2C = sceSifSetDma(&dtr->dma_data, 1);
@@ -142,7 +142,7 @@ INCLUDE_ASM("asm/anniversary/nonmatchings/cri/libadxe/dtr", DTR_Init);
 
 INCLUDE_ASM("asm/anniversary/nonmatchings/cri/libadxe/dtr", DTR_Finish);
 
-DTR DTR_Create(SJ sj, Sint32 arg1) {
+DTR DTR_Create(SJ sj, SJ arg1) {
     DTR dtr;
     Sint32 i;
 

--- a/src/anniversary/cri/libadxe/dvci.c
+++ b/src/anniversary/cri/libadxe/dvci.c
@@ -159,7 +159,7 @@ void dvCiEntryErrFunc(void (*func)(void *, const Char8 *, void *), void *obj) {
 }
 
 void dvci_to_large_to_yen(Char8 *path) {
-    Uint32 len = strlen(path);
+    size_t len = strlen(path);
     Sint32 i;
 
     for (i = 0; i < len; i++) {

--- a/src/anniversary/cri/libadxe/dvci_sub.c
+++ b/src/anniversary/cri/libadxe/dvci_sub.c
@@ -80,7 +80,7 @@ Sint32 dvci_charicmp(Char8 a, Char8 b) {
 }
 
 Sint32 dvci_stricmp(const Char8 *a, const Char8 *b) {
-    Sint32 len_a = strlen(a);
+    strlen_t len_a = strlen(a);
     Sint32 i;
 
     if (len_a != strlen(b)) {

--- a/src/anniversary/cri/libadxe/htci_sub.c
+++ b/src/anniversary/cri/libadxe/htci_sub.c
@@ -16,7 +16,7 @@ Char8 htg_ci_root_dir[257] = { 0 };
 Char8 htg_ci_head_name[33] = { 0 };
 
 Sint32 htci_is_inc_colon(const Char8 *str) {
-    Uint32 len;
+    size_t len;
     Sint32 i;
 
     len = strlen(str);
@@ -51,7 +51,7 @@ asm(".section .text");
 #endif
 
 void htci_conv_fname(const Char8 *flist, Char8 *fname) {
-    Sint32 len;
+    strlen_t len;
     Sint32 i;
     Char8 root_dir_last_char;
 
@@ -120,7 +120,7 @@ Sint32 htci_load_flist(const Char8 *flist, Sint8 *buf) {
     }
 
     SRD_SetHistory(0x6200);
-    offset_start = SRD_SceLseek(fd, 0, SCE_SEEK_SET);
+    offset_start = (Sint32)SRD_SceLseek(fd, 0, SCE_SEEK_SET);
     SRD_SetHistory(0x6201);
 
     if (offset_start < 0) {
@@ -132,7 +132,7 @@ Sint32 htci_load_flist(const Char8 *flist, Sint8 *buf) {
     }
 
     SRD_SetHistory(0x6300);
-    read_err = SRD_SceRead(fd, buf, offset_end);
+    read_err = SRD_SceRead(fd, buf, (Sint32)offset_end);
     SRD_SetHistory(0x6301);
 
     if (read_err < 0) {

--- a/src/anniversary/cri/libadxe/lsc.c
+++ b/src/anniversary/cri/libadxe/lsc.c
@@ -82,7 +82,7 @@ Sint32 LSC_EntryFname(LSC lsc) {
 Sint32 LSC_EntryFileRange(LSC lsc, const Char8 *fname, void *dir, Sint32 ofst, Sint32 fnsct) {
     LSC_STM *stm;
     Sint32 id;
-    Uint32 fname_length;
+    size_t fname_length;
     Sint32 i;
     Sint32 prev_stm_index;
 

--- a/src/anniversary/cri/libadxe/sj_rbf.c
+++ b/src/anniversary/cri/libadxe/sj_rbf.c
@@ -200,8 +200,8 @@ void SJRBF_GetChunk(SJRBF sjrbf, Sint32 id, Sint32 nbyte, SJCK *ck) {
 }
 
 void SJRBF_PutChunk(SJRBF sjrbf, Sint32 id, SJCK *ck) {
-    Sint32 temp_a2_4;
-    Sint32 temp_a3;
+    ptrdiff_t temp_a2_4;
+    ptrdiff_t temp_a3;
 
     if ((ck->len <= 0) || (ck->data == NULL)) {
         return;
@@ -220,7 +220,7 @@ void SJRBF_PutChunk(SJRBF sjrbf, Sint32 id, SJCK *ck) {
         temp_a3 = (ck->data - sjrbf->buf) + ck->len;
 
         if (sjrbf->bsize < temp_a3) {
-            temp_a2_4 = MIN(ck->len, temp_a3 - sjrbf->bsize);
+            temp_a2_4 = MIN(ck->len, temp_a3 - (ptrdiff_t)sjrbf->bsize);
             memcpy(sjrbf->buf, sjrbf->buf + (temp_a3 - temp_a2_4), temp_a2_4);
         }
 
@@ -314,7 +314,7 @@ Sint32 SJRBF_IsGetChunk(SJRBF sjrbf, Sint32 id, Sint32 nbyte, Sint32 *rbyte) {
     return unk == nbyte;
 }
 
-Sint32 SJRBF_GetBufPtr(SJ sj) {
+void *SJRBF_GetBufPtr(SJ sj) {
     SJRBF sjrbf = (SJRBF)sj;
     return sjrbf->buf;
 };

--- a/src/anniversary/cri/libadxe/sjr_clt.c
+++ b/src/anniversary/cri/libadxe/sjr_clt.c
@@ -8,27 +8,27 @@ Sint32 sjrmt_init_cnt = 0;
 
 // bss
 #if defined(TARGET_PS2)
-extern Sint32 D_006C0240[64];
-extern Sint32 D_006C0140[52];
+extern intptr_t D_006C0240[64];
+extern intptr_t D_006C0140[52];
 #else
-Sint32 D_006C0240[64];
-Sint32 D_006C0140[52];
+intptr_t D_006C0240[64]; // sjr_rpc_rcv_buf
+intptr_t D_006C0140[52]; // sjr_rpc_snd_buf
 #endif
 
 INCLUDE_ASM("asm/anniversary/nonmatchings/cri/libadxe/sjr_clt", SJRBF_CreateRmt);
 
 INCLUDE_ASM("asm/anniversary/nonmatchings/cri/libadxe/sjr_clt", SJMEM_CreateRmt);
 
-Sint32 SJUNI_CreateRmt(Sint32 arg0, Sint8 *arg1, Sint32 arg2) {
+void *SJUNI_CreateRmt(Sint32 arg0, Sint8 *arg1, Sint32 arg2) {
     D_006C0140[0] = arg0;
-    D_006C0140[1] = arg1;
+    D_006C0140[1] = (intptr_t)arg1;
     D_006C0140[2] = arg2;
     DTX_CallUrpc(34, D_006C0140, 3, D_006C0240, 1);
-    return D_006C0240[0];
+    return (void *)D_006C0240[0];
 }
 
-void SJRMT_Destroy(Sint32 sjrmt_han) {
-    D_006C0140[0] = sjrmt_han;
+void SJRMT_Destroy(void *sjrmt) {
+    D_006C0140[0] = sjrmt;
     DTX_CallUrpc(35, D_006C0140, 1, NULL, 0);
 }
 

--- a/src/anniversary/cri/libadxe/sjx.c
+++ b/src/anniversary/cri/libadxe/sjx.c
@@ -1,5 +1,6 @@
 #include "common.h"
 #include <cri/private/libadxe/dtx.h>
+#include <cri/private/libadxe/structs.h>
 
 #include <cri/cri_xpts.h>
 #include <cri/sj.h>
@@ -8,41 +9,6 @@
 #include <sifdev.h>
 
 #include <string.h>
-
-typedef struct {
-    Sint32 unk0;
-    SJ sj;
-} SJX_UNK_0;
-
-typedef struct {
-    Sint8 unk0;
-    Sint8 id;
-    Sint16 unk2;
-    SJX_UNK_0 *unk4;
-    SJCK chunk;
-} SJX_UNK_1;
-
-typedef struct {
-    Sint32 count;
-    Sint32 reserved4;
-    Sint32 reserved8;
-    Sint32 reservedC;
-    SJX_UNK_1 items[0];
-} SJX_UNK_2;
-
-typedef struct {
-    Sint8 used;
-    Sint8 unk1;
-    Sint16 unk2;
-    SJ sj;
-    Sint32 unk8;
-    Sint32 unkC;
-    SJX_UNK_0 *unk10;
-} SJX_OBJ;
-
-typedef SJX_OBJ *SJX;
-
-#define SJX_MAX_OBJ 32
 
 Char8 *sjx_build = "\nSJX Ver 1.05 Build:Sep 18 2003 09:59:53\n";
 Sint32 sjx_init_cnt = 0;
@@ -136,7 +102,7 @@ void SJX_Init() {
         memset(sjx_ee_work, 0, sizeof(sjx_ee_work));
         DTX_Init();
         sjx_wklen = 0x880;
-        sjx_eewk = (void *)(((Uint32)sjx_ee_work + 0x40) & ~0x3F);
+        sjx_eewk = (void *)(((uintptr_t)sjx_ee_work + 0x40) & ~0x3F);
 
         if (sjx_iopwk0 == NULL) {
             sjx_iopwk0 = sceSifAllocIopHeap(0x8D0);
@@ -147,7 +113,7 @@ void SJX_Init() {
             }
         }
 
-        sjx_iopwk = (void *)(((Uint32)sjx_iopwk0 + 0x40) & ~0x3F);
+        sjx_iopwk = (void *)(((uintptr_t)sjx_iopwk0 + 0x40) & ~0x3F);
         sjx_dtx = DTX_Create(0, sjx_eewk, sjx_iopwk, sjx_wklen);
 
         if (sjx_dtx == NULL) {
@@ -177,8 +143,8 @@ void SJX_Finish() {
     }
 }
 
-SJX SJX_Create(SJ sj, Sint32 arg1, Sint32 arg2) {
-    Sint32 rpc_buf[4];
+SJX SJX_Create(SJ sj, void *arg1, Sint32 arg2) {
+    uintptr_t rpc_buf[4];
     SJX sjx;
     Sint32 i;
 
@@ -198,10 +164,10 @@ SJX SJX_Create(SJ sj, Sint32 arg1, Sint32 arg2) {
     sjx->sj = sj;
     sjx->unkC = arg2;
     sjx->unk8 = arg1;
-    rpc_buf[0] = (Sint32)sj;
+    rpc_buf[0] = (uintptr_t)sj;
     rpc_buf[1] = arg1;
     rpc_buf[2] = arg2;
-    rpc_buf[3] = (Sint32)sjx;
+    rpc_buf[3] = (uintptr_t)sjx;
     sjx->unk10 = DTX_CallUrpc(0, rpc_buf, 4, rpc_buf, 1);
 
     if (sjx->unk10 == NULL) {

--- a/src/anniversary/port/flps2asm_stubs.c
+++ b/src/anniversary/port/flps2asm_stubs.c
@@ -1,50 +1,52 @@
 #include "common.h"
 #include "sf33rd/AcrSDK/ps2/flps2asm.h"
 
-void flPS2_Mem_move(const void *src, void *dst, u32 len) {
+#include <string.h>
+
+void flPS2_Mem_move(const void *src, void *dst, size_t len) {
     not_implemented(__func__);
 }
 
-void flPS2_Mem_move16(const void *src, void *dst, u32 len) {
+void flPS2_Mem_move16(const void *src, void *dst, size_t len) {
     not_implemented(__func__);
 }
 
-void flPS2_Mem_move16_8A(const void *src, void *dst, u32 len) {
+void flPS2_Mem_move16_8A(const void *src, void *dst, size_t len) {
     not_implemented(__func__);
 }
 
-void flPS2_Mem_move16_16A(const void *src, void *dst, u32 len) {
+void flPS2_Mem_move16_16A(const void *src, void *dst, size_t len) {
     not_implemented(__func__);
 }
 
-void flPS2_Mem_move32(const void *src, void *dst, u32 len) {
+void flPS2_Mem_move32(const void *src, void *dst, size_t len) {
     not_implemented(__func__);
 }
 
-void flPS2_Mem_move32_8A(const void *src, void *dst, u32 len) {
+void flPS2_Mem_move32_8A(const void *src, void *dst, size_t len) {
     not_implemented(__func__);
 }
 
-void flPS2_Mem_move32_16A(const void *src, void *dst, u32 len) {
+void flPS2_Mem_move32_16A(const void *src, void *dst, size_t len) {
     not_implemented(__func__);
 }
 
-void flPS2_Mem_move64(const void *src, void *dst, u32 len) {
+void flPS2_Mem_move64(const void *src, void *dst, size_t len) {
     not_implemented(__func__);
 }
 
-void flPS2_Clear_Mem(void *str, u32 len) {
+void flPS2_Clear_Mem(void *str, size_t len) {
     not_implemented(__func__);
 }
 
-void flPS2_Clear_Mem16_16A(void *str, u32 len) {
+void flPS2_Clear_Mem16_16A(void *str, size_t len) {
+    memset(str, 0, len * 16);
+}
+
+void flPS2_Fill_Mem(void *str, s32 c, size_t len) {
     not_implemented(__func__);
 }
 
-void flPS2_Fill_Mem(void *str, s32 c, u32 len) {
-    not_implemented(__func__);
-}
-
-void flPS2_Fill_Mem16_16A(void *str, s64 c, u32 len) {
+void flPS2_Fill_Mem16_16A(void *str, s64 c, size_t len) {
     not_implemented(__func__);
 }

--- a/src/anniversary/port/sdk_stubs.c
+++ b/src/anniversary/port/sdk_stubs.c
@@ -403,14 +403,6 @@ float cosf(float) {
     not_implemented(__func__);
 }
 
-float atan2(float) {
-    not_implemented(__func__);
-}
-
-float sqrt(float) {
-    not_implemented(__func__);
-}
-
 // libdma
 
 void sceDmaRecvN(sceDmaChan *d, void *addr, int size) {

--- a/src/anniversary/sf33rd/AcrSDK/MiddleWare/PS2/CapSndEng/cse.c
+++ b/src/anniversary/sf33rd/AcrSDK/MiddleWare/PS2/CapSndEng/cse.c
@@ -132,7 +132,7 @@ s32 cseSendBd2SpuWithId(void *ee_addr, u32 size, u32 bank, u32 id) {
     if (cseSysWork.SpuBankId[bank] != id) {
         cseSysWork.SpuBankId[bank] = id;
         param.cmd = 0x30000000;
-        param.e_addr = (u32)ee_addr;
+        param.e_addr = (uintptr_t)ee_addr;
         param.s_addr = mlMemMapGetBankAddr(bank);
         param.size = size;
         mlRpcQueueSetData(3, &param, sizeof(CSE_SPUID_PARAM));

--- a/src/anniversary/sf33rd/AcrSDK/MiddleWare/PS2/CapSndEng/emlRefPhd.c
+++ b/src/anniversary/sf33rd/AcrSDK/MiddleWare/PS2/CapSndEng/emlRefPhd.c
@@ -44,7 +44,7 @@ s32 GetNumSplit(_ps2_head_chunk *pHEAD, u8 prog) {
         return -1;
     }
 
-    pPROG = (_ps2_prog_chunk *)((u32)&pHEAD->tag + (u32)pHEAD->progChunkOffset);
+    pPROG = (_ps2_prog_chunk *)((uintptr_t)&pHEAD->tag + (u32)pHEAD->progChunkOffset);
     if (IsSafeProgChunk(pPROG) != 1) {
         return -2;
     }
@@ -58,7 +58,7 @@ s32 GetNumSplit(_ps2_head_chunk *pHEAD, u8 prog) {
         return -11;
     }
 
-    pPPRM = (_ps2_prog_param *)((u32)pPROG + offset);
+    pPPRM = (_ps2_prog_param *)((uintptr_t)pPROG + offset);
     return pPPRM->nSplit;
 }
 
@@ -71,10 +71,10 @@ s32 GetPhdParam(CSE_PHDPADDR *pHDPA, _ps2_head_chunk *pHEAD, u8 prog, u8 note, u
     _ps2_smpl_param *pSPRM;
     _ps2_vagi_param *pVPRM;
 
-    pPROG = (_ps2_prog_chunk *)((u32)&pHEAD->tag + (u32)pHEAD->progChunkOffset);
-    pSMPL = (_ps2_smpl_chunk *)((u32)&pHEAD->tag + (u32)pHEAD->smplChunkOffset);
-    pVAGI = (_ps2_vagi_chunk *)((u32)&pHEAD->tag + (u32)pHEAD->vagiChunkOffset);
-    
+    pPROG = (_ps2_prog_chunk *)((uintptr_t)&pHEAD->tag + (u32)pHEAD->progChunkOffset);
+    pSMPL = (_ps2_smpl_chunk *)((uintptr_t)&pHEAD->tag + (u32)pHEAD->smplChunkOffset);
+    pVAGI = (_ps2_vagi_chunk *)((uintptr_t)&pHEAD->tag + (u32)pHEAD->vagiChunkOffset);
+
     if (IsSafeHeadChunk(pHEAD) != 1) {
         return -1;
     }
@@ -91,11 +91,11 @@ s32 GetPhdParam(CSE_PHDPADDR *pHDPA, _ps2_head_chunk *pHEAD, u8 prog, u8 note, u
         return -4;
     }
 
-    pPPRM = (_ps2_prog_param *)((u32)pPROG + pPROG->progParamOffset[prog]);
+    pPPRM = (_ps2_prog_param *)((uintptr_t)pPROG + pPROG->progParamOffset[prog]);
     pSBLK = &pPPRM->splitBlock[index];
     pSPRM = &pSMPL->smplParam[pSBLK->sampleIndex];
     pVPRM = &pVAGI->vagiParam[pSPRM->vagiIndex];
-    
+
     if (!(pSBLK->lowKey > note) && !(note > pSBLK->highKey)) {
         pHDPA->pPprm = pPPRM;
         pHDPA->pSblk = pSBLK;
@@ -114,7 +114,7 @@ s32 CalcPhdParam(CSE_PHDP *pPHDP, CSE_PHDPADDR *pHDPA, u8 note, u32 SpuTopAddr) 
     pPHDP->vol = ((pPHDP->vol * pHDPA->pSblk->vol) / 127);
     pPHDP->vol = ((pPHDP->vol * pHDPA->pSprm->vol) / 127);
     pan = pHDPA->pPprm->pan - 64;
-    
+
     if (pan < -64) {
         pan = -64;
     } else if (pan > 63) {

--- a/src/anniversary/sf33rd/AcrSDK/common/fbms.c
+++ b/src/anniversary/sf33rd/AcrSDK/common/fbms.c
@@ -1,7 +1,7 @@
 #include "common.h"
 #include "structs.h"
 
-s32 fmsCalcSpace(FL_FMS *lp) {
+ptrdiff_t fmsCalcSpace(FL_FMS *lp) {
     return lp->frame[1] - lp->frame[0];
 }
 
@@ -9,8 +9,8 @@ s32 fmsInitialize(FL_FMS *lp, void *memory_ptr, s32 memsize, s32 memalign) {
     memsize = ~(memalign - 1) & (memsize + memalign - 1);
     lp->memoryblock = (u8 *)memory_ptr;
     lp->align = memalign;
-    lp->baseandcap[0] = (u8 *)((u32)lp->memoryblock + lp->align - 1 & ~(lp->align - 1));
-    lp->baseandcap[1] = (u8 *)(((u32)lp->memoryblock + memsize + lp->align - 1) & ~(lp->align - 1));
+    lp->baseandcap[0] = (u8 *)((uintptr_t)lp->memoryblock + lp->align - 1 & ~(lp->align - 1));
+    lp->baseandcap[1] = (u8 *)(((uintptr_t)lp->memoryblock + memsize + lp->align - 1) & ~(lp->align - 1));
     lp->frame[0] = lp->baseandcap[0];
     lp->frame[1] = lp->baseandcap[1];
     return 1;
@@ -18,7 +18,7 @@ s32 fmsInitialize(FL_FMS *lp, void *memory_ptr, s32 memsize, s32 memalign) {
 
 void *fmsAllocMemory(FL_FMS *lp, s32 bytes, s32 heapnum) {
     void *pMem;
-    bytes = ~(lp->align - 1) & ((u32)bytes + lp->align - 1);
+    bytes = ~(lp->align - 1) & ((uintptr_t)bytes + lp->align - 1);
 
     if (lp->frame[0] + bytes > lp->frame[1]) {
         return NULL;

--- a/src/anniversary/sf33rd/AcrSDK/common/memfound.c
+++ b/src/anniversary/sf33rd/AcrSDK/common/memfound.c
@@ -16,7 +16,7 @@ u32 mflGetSpace() {
     return plmemGetSpace(&sysmemmgr);
 }
 
-u32 mflGetFreeSpace() {
+size_t mflGetFreeSpace() {
     return plmemGetFreeSpace(&sysmemmgr);
 }
 

--- a/src/anniversary/sf33rd/AcrSDK/common/memmgr.c
+++ b/src/anniversary/sf33rd/AcrSDK/common/memmgr.c
@@ -2,8 +2,8 @@
 #include "common.h"
 #include "sf33rd/AcrSDK/common/prilay.h"
 
-#define ALIGN(ptr, len, alignment) ((~(alignment - 1)) & ((u32)(ptr) + len + alignment - 1))
-#define ALIGN_DOWN(ptr, len, alignment) ((~(alignment - 1)) & ((u32)(ptr) - len))
+#define ALIGN(ptr, len, alignment) ((~(alignment - 1)) & ((uintptr_t)(ptr) + len + alignment - 1))
+#define ALIGN_DOWN(ptr, len, alignment) ((~(alignment - 1)) & ((uintptr_t)(ptr) - len))
 
 static u32 plmemPullHandle(MEM_MGR *memmgr);
 static void plmemAppendBlockList(MEM_MGR *memmgr, u32 han);
@@ -17,9 +17,9 @@ void plmemInit(MEM_MGR *memmgr, MEM_BLOCK *block, s32 count, void *mem_ptr, s32 
     memmgr->memalign = memalign;
 
     if (direction != 0) {
-        memmgr->memptr = (u8 *)(~(memalign - 1) & ((u32)mem_ptr + memalign - 1));
+        memmgr->memptr = (u8 *)(~(memalign - 1) & ((uintptr_t)mem_ptr + memalign - 1));
     } else {
-        memmgr->memptr = (u8 *)(~(memalign - 1) & ((u32)mem_ptr + memsize));
+        memmgr->memptr = (u8 *)(~(memalign - 1) & ((uintptr_t)mem_ptr + memsize));
     }
 
     memmgr->memnow = memmgr->memptr;
@@ -57,10 +57,10 @@ u32 plmemRegisterAlign(MEM_MGR *memmgr, s32 len, s32 align) {
 
     if (memmgr->direction != 0) {
         memmgr->block[han].ptr = memmgr->memnow;
-        memmgr->memnow = (u8 *)(~(align - 1) & ((u32)&memmgr->block[han].ptr[len] + align - 1));
+        memmgr->memnow = (u8 *)(~(align - 1) & ((uintptr_t)&memmgr->block[han].ptr[len] + align - 1));
         // memmgr->memnow = (u8*)ALIGN(memmgr->block[han].ptr, len, align);
     } else {
-        memmgr->block[han].ptr = (u8 *)(~(align - 1) & (u32)(memmgr->memnow - len));
+        memmgr->block[han].ptr = (u8 *)(~(align - 1) & (uintptr_t)(memmgr->memnow - len));
         // memmgr->block[han].ptr = (u8 *)ALIGN_DOWN(memmgr->memnow, len, align);
         memmgr->memnow = memmgr->block[han].ptr;
     }
@@ -73,7 +73,7 @@ u32 plmemRegisterAlign(MEM_MGR *memmgr, s32 len, s32 align) {
 
 u32 plmemRegisterS(MEM_MGR *memmgr, s32 len) {
     u32 han;
-    u32 len2;
+    size_t len2;
     u32 size;
     MEM_BLOCK *now_block;
     MEM_BLOCK *next_block;
@@ -159,7 +159,7 @@ u32 plmemRegisterS(MEM_MGR *memmgr, s32 len) {
 }
 
 void *plmemTemporaryUse(MEM_MGR *memmgr, s32 len) {
-    u32 tmp;
+    size_t tmp;
 
     len = ALIGN(NULL, len, memmgr->memalign);
     tmp = plmemGetFreeSpace(memmgr);
@@ -277,7 +277,7 @@ u32 plmemGetSpace(MEM_MGR *memmgr) {
     return memmgr->memsize - memmgr->used_size;
 }
 
-u32 plmemGetFreeSpace(MEM_MGR *memmgr) {
+size_t plmemGetFreeSpace(MEM_MGR *memmgr) {
     if (memmgr->direction != 0) {
         return memmgr->memptr + memmgr->memsize - memmgr->memnow - memmgr->tmemsize;
     }

--- a/src/anniversary/sf33rd/AcrSDK/common/pltim2.c
+++ b/src/anniversary/sf33rd/AcrSDK/common/pltim2.c
@@ -369,7 +369,7 @@ u8 *GetTim2PictureData(u8 *lpFile, s32 /* unused */, s32 Mipmap) {
         lpTim2MipmapHead = lpData;
 
         for (lp0 = 0; lp0 < lpTim2PictureHead[0x11] - 1; lp0++) {
-            lpTim2MipmapSubHead[lp0] = (u8 *)((u32)lpData + (lp0 << 2) + 0x10);
+            lpTim2MipmapSubHead[lp0] = (u8 *)((uintptr_t)lpData + (lp0 << 2) + 0x10);
         }
 
         if (lpTim2PictureHead[0x11] < 5) {
@@ -429,7 +429,7 @@ u8 *GetTim2ClutData(u8 *lpFile, s32 /* unused */) {
         lpTim2MipmapHead = lpData;
 
         for (lp0 = 0; lp0 < lpTim2PictureHead[0x11]; lp0++) {
-            lpTim2MipmapSubHead[lp0] = (u8 *)((u32)lpData + (lp0 << 2) + 0x10);
+            lpTim2MipmapSubHead[lp0] = (u8 *)((uintptr_t)lpData + (lp0 << 2) + 0x10);
         }
 
         if (lpTim2PictureHead[0x11] < 5) {

--- a/src/anniversary/sf33rd/AcrSDK/ps2/flps2debug.c
+++ b/src/anniversary/sf33rd/AcrSDK/ps2/flps2debug.c
@@ -80,7 +80,7 @@ void flPS2DebugStrDisp() {
     u64 *giftag_keep_ptr;
     u32 code;
     u32 disp_ctr;
-    s32 length;
+    ptrdiff_t length;
     s32 lp0;
     u32 col;
     u32 colold;
@@ -174,7 +174,7 @@ void flPS2DebugStrDisp() {
             buff_ptr++;
         }
 
-        flPs2State.SystemTmpBuffNow = (u32)work_ptr;
+        flPs2State.SystemTmpBuffNow = (uintptr_t)work_ptr;
 
         if (disp_ctr != 0) {
             *giftag_keep_ptr++ = SCE_GIF_SET_TAG(disp_ctr, 1, 0, 0, SCE_GIF_REGLIST, 6);
@@ -190,8 +190,8 @@ void flPS2DebugStrDisp() {
         *work_ptr = length + 0x6FFFFFFF;
         ((u32 *)work_ptr)[0] |= 0x80000000;
         ((u32 *)work_ptr)[2] = 0x13000000;
-        ((u32 *)work_ptr)[3] = (length - 1) | 0x51000000;
-        flPS2DmaAddQueue2(0, ((u32)keep_ptr & 0xFFFFFFF) | 0x40000000, (u32)keep_ptr, &flPs2VIF1Control);
+        ((u32 *)work_ptr)[3] = (u32)((length - 1) | 0x51000000);
+        flPS2DmaAddQueue2(0, ((uintptr_t)keep_ptr & 0xFFFFFFF) | 0x40000000, (uintptr_t)keep_ptr, &flPs2VIF1Control);
     }
 
     flPS2DebugStrClear();
@@ -201,7 +201,7 @@ s32 flPrintL(s32 posi_x, s32 posi_y, const s8 *format, ...) {
     s8 *va_ptr;
     s8 code;
     s8 str[512];
-    s32 len;
+    strlen_t len;
     s32 i;
     RenderBuffer *buff_ptr;
 
@@ -221,8 +221,7 @@ s32 flPrintL(s32 posi_x, s32 posi_y, const s8 *format, ...) {
     for (i = 0; i < len; i++) {
         code = str[i];
 
-        // code != 0x20 skips spaces
-        if ((code >= 0x10) && (code < 0x80) && (code != 0x20)) {
+        if ((code >= 0x10) && (code < 0x80) && (code != ' ')) {
             buff_ptr->x = posi_x * 8;
             buff_ptr->y = posi_y * 8;
             buff_ptr->code = code;
@@ -465,7 +464,7 @@ void flPS2LoadCheckFlush() {
 void flPS2SystemError(s32 error_level, s8 *format, ...) {
     va_list args;
     s8 str[512];
-    s32 len;
+    strlen_t len;
 
     flFlip(0);
     va_start(args, format);

--- a/src/anniversary/sf33rd/AcrSDK/ps2/flps2dma.c
+++ b/src/anniversary/sf33rd/AcrSDK/ps2/flps2dma.c
@@ -11,14 +11,14 @@
 // sbss
 u64 flPs2StoreImageOldIMR;
 static u32 flPs2StoreImageSize;
-static u32 flPs2StoreImageAdrs;
+static uintptr_t flPs2StoreImageAdrs;
 
 static __int128 vif1_fifo = (__int128)0x06000000;
 static u32 *dma_chcr_adrs[10] = { (u32 *)0x10008000, (u32 *)0x10009000, (u32 *)0x1000A000, (u32 *)0x1000B000,
                                   (u32 *)0x1000B400, (u32 *)0x1000C000, (u32 *)0x1000C400, (u32 *)0x1000C800,
                                   (u32 *)0x1000D000, (u32 *)0x1000D400 };
 
-u32 flPS2DmaAddCntTag(u32 tag, s32 qwc, s32 irq, s32 /*unused*/) {
+uintptr_t flPS2DmaAddCntTag(uintptr_t tag, s32 qwc, s32 irq, s32 /*unused*/) {
     QWORD *wk_ptr = (QWORD *)tag;
     wk_ptr->UI128 = 0;
     wk_ptr->UI32[0] = qwc + 0x10000000;
@@ -30,9 +30,9 @@ u32 flPS2DmaAddCntTag(u32 tag, s32 qwc, s32 irq, s32 /*unused*/) {
     return tag + 0x10;
 }
 
-u32 flPS2DmaAddRefTag(u32 tag, s32 qwc, u32 data_adrs, s32 irq, s32 /*unused*/) {
+uintptr_t flPS2DmaAddRefTag(uintptr_t tag, s32 qwc, uintptr_t data_adrs, s32 irq, s32 /*unused*/) {
     QWORD *wk_ptr = (QWORD *)tag;
-    u32 addr = data_adrs & 0xFFFFFFF;
+    uintptr_t addr = data_adrs & 0xFFFFFFF;
     u32 spr_flag = 0;
 
     if ((data_adrs & 0x70000000) == 0x70000000) {
@@ -41,7 +41,7 @@ u32 flPS2DmaAddRefTag(u32 tag, s32 qwc, u32 data_adrs, s32 irq, s32 /*unused*/) 
 
     wk_ptr->UI128 = 0;
     wk_ptr->UI32[0] = qwc + 0x30000000;
-    wk_ptr->UI32[1] = addr | spr_flag;
+    wk_ptr->UI32[1] = (u32)(addr | spr_flag);
 
     if (irq == 1) {
         wk_ptr->UI32[0] |= 0x80000000;
@@ -50,9 +50,9 @@ u32 flPS2DmaAddRefTag(u32 tag, s32 qwc, u32 data_adrs, s32 irq, s32 /*unused*/) 
     return tag + 0x10;
 }
 
-u32 flPS2DmaAddRefeTag(u32 tag, s32 qwc, u32 data_adrs, s32 irq, s32 /*unused*/) {
+uintptr_t flPS2DmaAddRefeTag(uintptr_t tag, s32 qwc, uintptr_t data_adrs, s32 irq, s32 /*unused*/) {
     QWORD *wk_ptr = (QWORD *)tag;
-    u32 addr = data_adrs & 0xFFFFFFF;
+    uintptr_t addr = data_adrs & 0xFFFFFFF;
     u32 spr_flag = 0;
 
     if ((data_adrs & 0x70000000) == 0x70000000) {
@@ -61,7 +61,7 @@ u32 flPS2DmaAddRefeTag(u32 tag, s32 qwc, u32 data_adrs, s32 irq, s32 /*unused*/)
 
     wk_ptr->UI128 = 0;
     wk_ptr->UI32[0] = qwc;
-    wk_ptr->UI32[1] = addr | spr_flag;
+    wk_ptr->UI32[1] = (u32)(addr | spr_flag);
 
     if (irq == 1) {
         wk_ptr->UI32[0] |= 0x80000000;
@@ -70,7 +70,7 @@ u32 flPS2DmaAddRefeTag(u32 tag, s32 qwc, u32 data_adrs, s32 irq, s32 /*unused*/)
     return tag + 0x10;
 }
 
-u32 flPS2DmaAddEndTag(u32 tag, s32 qwc, s32 irq, s32 /*unused*/) {
+uintptr_t flPS2DmaAddEndTag(uintptr_t tag, s32 qwc, s32 irq, s32 /*unused*/) {
     QWORD *wk_ptr = (QWORD *)tag;
 
     wk_ptr->UI128 = 0;
@@ -83,7 +83,7 @@ u32 flPS2DmaAddEndTag(u32 tag, s32 qwc, s32 irq, s32 /*unused*/) {
     return tag + 0x10;
 }
 
-u32 flPS2VIF1CodeAddDirectHL(u32 tag, s32 qwc) {
+uintptr_t flPS2VIF1CodeAddDirectHL(uintptr_t tag, s32 qwc) {
     QWORD *pkt = (QWORD *)tag;
 
     pkt->UI32[0] = 0;
@@ -114,15 +114,15 @@ u32 flPS2VIF1CalcEndLoadImageSize(s32 /*unused*/) {
     return 0x40;
 }
 
-u32 flPS2VIF1MakeLoadImage(u32 buff_ptr, u32 irq, u32 data_ptr, u32 size, s16 dbp, s16 dbw, s16 dpsm, s16 x, s16 y,
-                           s16 w, s16 h) {
+uintptr_t flPS2VIF1MakeLoadImage(uintptr_t buff_ptr, u32 irq, uintptr_t data_ptr, u32 size, s16 dbp, s16 dbw, s16 dpsm,
+                                 s16 x, s16 y, s16 w, s16 h) {
     u_long *work_ptr;
     u32 lp0;
     u32 count;
     u32 trans_size;
     s16 wk_h;
     FLPS2LoadImageData *load_image;
-    u32 last_tag;
+    uintptr_t last_tag;
 
     last_tag = 0;
     count = size / 0x70000;
@@ -183,7 +183,7 @@ u32 flPS2VIF1MakeLoadImage(u32 buff_ptr, u32 irq, u32 data_ptr, u32 size, s16 db
         }
 
         load_image = (FLPS2LoadImageData *)work_ptr;
-        flPS2DmaAddCntTag((u32)load_image, 6, 0, 0);
+        flPS2DmaAddCntTag((uintptr_t)load_image, 6, 0, 0);
         load_image->dmatag.data.UI32[2] = 0x13000000;
         load_image->dmatag.data.UI32[3] = 0x51000006;
 
@@ -205,15 +205,15 @@ u32 flPS2VIF1MakeLoadImage(u32 buff_ptr, u32 irq, u32 data_ptr, u32 size, s16 db
         if (lp0 >= count - 1) {
             load_image->giftag1.data.UI64[0] = SCE_GIF_SET_TAG(size / 16, 1, 0, 0, SCE_GIF_IMAGE, 0);
             load_image->giftag1.data.UI64[1] = 0;
-            flPS2DmaAddRefeTag((u32)load_image + 0x70, size / 16, data_ptr, irq, 0);
+            flPS2DmaAddRefeTag((uintptr_t)load_image + 0x70, size / 16, data_ptr, irq, 0);
 
             load_image->dmatag1.data.UI32[2] = 0;
             load_image->dmatag1.data.UI32[3] = (size / 16) | 0x51000000;
-            last_tag = (u32)load_image + 0x70;
+            last_tag = (uintptr_t)load_image + 0x70;
         } else {
             load_image->giftag1.data.UI64[0] = SCE_GIF_SET_TAG(0xF000, 0, 0, 0, 2, 0);
             load_image->giftag1.data.UI64[1] = 0;
-            flPS2DmaAddRefTag((u32)load_image + 0x70, 0x7000, data_ptr, 0, 0);
+            flPS2DmaAddRefTag((uintptr_t)load_image + 0x70, 0x7000, data_ptr, 0, 0);
 
             load_image->dmatag1.data.UI32[2] = 0;
             load_image->dmatag1.data.UI32[3] = 0x51000000 | 0x7000;
@@ -232,10 +232,10 @@ u32 flPS2VIF1MakeLoadImage(u32 buff_ptr, u32 irq, u32 data_ptr, u32 size, s16 db
     return last_tag;
 }
 
-void flPS2VIF1MakeEndLoadImage(u32 buff_ptr, u32 irq) {
+void flPS2VIF1MakeEndLoadImage(uintptr_t buff_ptr, u32 irq) {
     FLPS2LoadEndData *load_end = (FLPS2LoadEndData *)buff_ptr;
-    flPS2DmaAddEndTag((u32)load_end, 3, irq, 0);
-    flPS2VIF1CodeAddDirectHL((u32)load_end + 0x10, 2);
+    flPS2DmaAddEndTag((uintptr_t)load_end, 3, irq, 0);
+    flPS2VIF1CodeAddDirectHL((uintptr_t)load_end + 0x10, 2);
 
     load_end->giftag.UI64[0] = SCE_GIF_SET_TAG(1, 1, 0, 0, SCE_GIF_PACKED, 1);
     load_end->giftag.UI64[1] = SCE_GIF_PACKED_AD;
@@ -244,7 +244,7 @@ void flPS2VIF1MakeEndLoadImage(u32 buff_ptr, u32 irq) {
     load_end->texflush.UI64[1] = SCE_GS_TEXFLUSH;
 }
 
-void flPS2StoreImageB(u32 load_ptr, u32 size, s16 dbp, s16 dbw, s16 dpsm, s16 x, s16 y, s16 w, s16 h) {
+void flPS2StoreImageB(uintptr_t load_ptr, u32 size, s16 dbp, s16 dbw, s16 dpsm, s16 x, s16 y, s16 w, s16 h) {
     sceDmaChan *dma_channel;
     u32 lp0;
     u32 count;
@@ -311,7 +311,7 @@ void flPS2StoreImageB(u32 load_ptr, u32 size, s16 dbp, s16 dbw, s16 dpsm, s16 x,
         }
 
         store_image = (FLPS2StoreImageData *)flPS2GetSystemTmpBuff(0x90, 0x10);
-        flPS2DmaAddEndTag((u32)store_image, 7, 0, 0);
+        flPS2DmaAddEndTag((uintptr_t)store_image, 7, 0, 0);
         store_image->dmatag.data.UI32[2] = 0;
         store_image->dmatag.data.UI32[3] = 0;
 
@@ -408,12 +408,12 @@ void flPS2DmaInitControl(FLPS2VIF1Control *dma_ptr, u32 queue_size, void *handle
     flPs2GsHandler = AddIntcHandler(0, &IntGsStoreImageHandler, 0);
 }
 
-s32 flPS2DmaAddQueue2(s32 type, u32 data_adrs, u32 endtag_adrs, FLPS2VIF1Control *dma_ptr) {
+s32 flPS2DmaAddQueue2(s32 type, uintptr_t data_adrs, uintptr_t endtag_adrs, FLPS2VIF1Control *dma_ptr) {
     u32 dma_chcr;
     sceDmaChan *dma_channel;
-    u32 *dma_queue;
+    uintptr_t *dma_queue;
     s32 dma_index;
-    u32 *old_tag;
+    uintptr_t *old_tag;
     u32 qwc;
 
     flDebugAQNum += 1;
@@ -429,7 +429,7 @@ s32 flPS2DmaAddQueue2(s32 type, u32 data_adrs, u32 endtag_adrs, FLPS2VIF1Control
         dma_index = flPs2State.SystemIndex;
 
         if (dma_ptr->queue_ctr[dma_index] <= dma_ptr->queue_size - 1) {
-            dma_queue = (u32 *)flPS2GetSystemBuffAdrs(dma_ptr->dma_queue_handle[dma_index]);
+            dma_queue = (uintptr_t *)flPS2GetSystemBuffAdrs(dma_ptr->dma_queue_handle[dma_index]);
             dma_ptr->queue_ctr[dma_index] += 1;
             dma_queue[dma_ptr->queue_ptr0[dma_index]++] = data_adrs;
 
@@ -443,7 +443,7 @@ s32 flPS2DmaAddQueue2(s32 type, u32 data_adrs, u32 endtag_adrs, FLPS2VIF1Control
             return 0;
         }
     } else if (dma_ptr->old_queue_data && dma_ptr->old_endtag) {
-        old_tag = (u32 *)dma_ptr->old_endtag;
+        old_tag = (uintptr_t *)dma_ptr->old_endtag;
 
         switch ((dma_ptr->old_queue_data & 0xF0000000) >> 0x1C) {
         default:

--- a/src/anniversary/sf33rd/AcrSDK/ps2/flps2etc.c
+++ b/src/anniversary/sf33rd/AcrSDK/ps2/flps2etc.c
@@ -113,7 +113,7 @@ s32 flFileWrite(s8 *filename, void *buf, s32 len) {
     return 1;
 }
 
-s32 flFileAppend(s8 *filename, void *buf, s32 len) {
+s32 flFileAppend(s8 *filename, void *buf, ssize_t len) {
     s32 fd;
     s8 temp[2048];
     s8 *p;
@@ -131,7 +131,7 @@ s32 flFileAppend(s8 *filename, void *buf, s32 len) {
     }
 
     sceLseek(fd, 0, 2);
-    sceWrite(fd, buf, len);
+    sceWrite(fd, buf, (s32)len);
     sceClose(fd);
     ADXM_Unlock();
     return 1;
@@ -294,7 +294,7 @@ void flPS2SystemTmpBuffFlush() {
     case 1:
         len = 0x80000;
         flPs2State.SystemTmpBuffStartAdrs =
-            (u32)flPS2GetSystemBuffAdrs(flPs2State.SystemTmpBuffHandle[flPs2State.SystemIndex]);
+            (uintptr_t)flPS2GetSystemBuffAdrs(flPs2State.SystemTmpBuffHandle[flPs2State.SystemIndex]);
         flPs2State.SystemTmpBuffNow = flPs2State.SystemTmpBuffStartAdrs;
         flPs2State.SystemTmpBuffEndAdrs = flPs2State.SystemTmpBuffStartAdrs + len;
 
@@ -305,9 +305,9 @@ void flPS2SystemTmpBuffFlush() {
     }
 }
 
-u32 flPS2GetSystemTmpBuff(s32 len, s32 align) {
-    u32 now;
-    u32 new_now;
+uintptr_t flPS2GetSystemTmpBuff(s32 len, s32 align) {
+    uintptr_t now;
+    uintptr_t new_now;
 
     now = flPs2State.SystemTmpBuffNow;
     now = ~(align - 1) & (now + align - 1);

--- a/src/anniversary/sf33rd/AcrSDK/ps2/flps2ps.c
+++ b/src/anniversary/sf33rd/AcrSDK/ps2/flps2ps.c
@@ -15,6 +15,6 @@ s32 flPS2psAddQueue(QWORD *dma_data) {
     dma_data->I32[2] = 0x13000000;
     dma_data->I32[3] = (qwc - 1) | 0x51000000;
     flPS2_Mem_move16_16A(dma_data, (void *)dst, qwc);
-    flPS2DmaAddQueue2(0, ((u32)dst & 0x0FFFFFFF) | 0x40000000, (u32)dst, &flPs2VIF1Control);
+    flPS2DmaAddQueue2(0, ((uintptr_t)dst & 0x0FFFFFFF) | 0x40000000, (uintptr_t)dst, &flPs2VIF1Control);
     return 1;
 }

--- a/src/anniversary/sf33rd/AcrSDK/ps2/flps2render.c
+++ b/src/anniversary/sf33rd/AcrSDK/ps2/flps2render.c
@@ -500,6 +500,9 @@ s32 flSetRenderState(enum _FLSETRENDERSTATE func, u32 value) {
         }
 
         break;
+
+    default:
+        break;
     }
 
     return 1;

--- a/src/anniversary/sf33rd/AcrSDK/ps2/flps2render.c
+++ b/src/anniversary/sf33rd/AcrSDK/ps2/flps2render.c
@@ -513,7 +513,7 @@ s32 flPS2SendRenderState_SCISSOR(s32 dx, s32 dy, s32 dw, s32 dh, u32 flag) {
     s32 dx2;
     s32 dy2;
     u32 qwc;
-    u32 keep_ptr;
+    uintptr_t keep_ptr;
     QWORD *lpWork;
 
     if (dx < 0) {
@@ -542,7 +542,7 @@ s32 flPS2SendRenderState_SCISSOR(s32 dx, s32 dy, s32 dw, s32 dh, u32 flag) {
         qwc = 3;
     }
 
-    keep_ptr = (u32)lpWork;
+    keep_ptr = (uintptr_t)lpWork;
     lpWork->UI64[0] = (qwc + 0x70000000) | 0x80000000;
     lpWork->UI32[2] = 0x13000000;
     lpWork->UI32[3] = (qwc | 0x50000000);
@@ -603,7 +603,7 @@ s32 flPS2SendRenderState_SCISSOR(s32 dx, s32 dy, s32 dw, s32 dh, u32 flag) {
 
 s32 flPS2SendRenderState_ZBUF(u32 render_state, u32 flag) {
     u32 qwc;
-    u32 keep_ptr;
+    uintptr_t keep_ptr;
     s32 zbp;
     s32 psm;
     s32 zmsk;
@@ -628,7 +628,7 @@ s32 flPS2SendRenderState_ZBUF(u32 render_state, u32 flag) {
         qwc = 3;
     }
 
-    keep_ptr = (u32)lpWork;
+    keep_ptr = (uintptr_t)lpWork;
     lpWork->UI64[0] = (qwc + 0x70000000) | 0x80000000;
     lpWork->UI32[2] = 0x13000000;
     lpWork->UI32[3] = (qwc | 0x50000000);
@@ -665,7 +665,7 @@ s32 flPS2SendRenderState_ZBUF(u32 render_state, u32 flag) {
 
 s32 flPS2SendRenderState_TEST(u32 render_state, u32 flag) {
     u32 qwc;
-    u32 keep_ptr;
+    uintptr_t keep_ptr;
     QWORD *lpWork;
     u_long test;
     s32 ate;
@@ -765,7 +765,7 @@ s32 flPS2SendRenderState_TEST(u32 render_state, u32 flag) {
         qwc = 3;
     }
 
-    keep_ptr = (u32)lpWork;
+    keep_ptr = (uintptr_t)lpWork;
     (void)test;
 
     lpWork->UI64[0] = (qwc + 0x70000000) | 0x80000000;
@@ -811,7 +811,7 @@ s32 flPS2SendRenderState_TEST(u32 render_state, u32 flag) {
 
 s32 flPS2SendRenderState_ALPHA(u32 render_state, u32 flag) {
     u32 qwc;
-    u32 keep_ptr;
+    uintptr_t keep_ptr;
     u_long alpha;
     QWORD *lpWork;
     u32 blend_ope;
@@ -824,7 +824,7 @@ s32 flPS2SendRenderState_ALPHA(u32 render_state, u32 flag) {
         qwc = 3;
     }
 
-    keep_ptr = (u32)lpWork;
+    keep_ptr = (uintptr_t)lpWork;
 
     lpWork->UI64[0] = (qwc + 0x70000000) | 0x80000000;
     lpWork->UI32[2] = 0x13000000;
@@ -1193,12 +1193,12 @@ s32 flPS2SendRenderState_ALPHA(u32 render_state, u32 flag) {
 
 s32 flPS2SendRenderState_FOGCOL(u32 fogcol) {
     u32 qwc;
-    u32 keep_ptr;
+    uintptr_t keep_ptr;
     QWORD *lpWork;
 
     lpWork = (QWORD *)flPS2GetSystemTmpBuff(0x30, 0x10);
     qwc = 2;
-    keep_ptr = (u32)lpWork;
+    keep_ptr = (uintptr_t)lpWork;
 
     lpWork->UI64[0] = (qwc + 0x70000000) | 0x80000000;
     lpWork->UI32[2] = 0x13000000;
@@ -1218,12 +1218,12 @@ s32 flPS2SendRenderState_FOGCOL(u32 fogcol) {
 
 s32 flPS2SendRenderState_TEX1(u32 render_state, u32 flag) {
     u32 qwc;
-    u32 keep_ptr;
+    uintptr_t keep_ptr;
     QWORD *lpWork;
 
     lpWork = (QWORD *)flPS2GetSystemTmpBuff(0x30, 0x10);
     qwc = 2;
-    keep_ptr = (u32)lpWork;
+    keep_ptr = (uintptr_t)lpWork;
 
     lpWork->UI64[0] = (qwc + 0x70000000) | 0x80000000;
     lpWork->UI32[2] = 0x13000000;

--- a/src/anniversary/sf33rd/AcrSDK/ps2/flps2vram.c
+++ b/src/anniversary/sf33rd/AcrSDK/ps2/flps2vram.c
@@ -1222,7 +1222,7 @@ s32 flPS2UnlockTexture(FLTexture *lpflTexture) {
 
     lpflTexture->desc &= ~2;
 
-    if (trans_ptr != NULL) {
+    if (trans_ptr != 0) {
         if (lpflTexture->flag == 1 || lpflTexture->flag == 4) {
             flPS2DeleteVramList(lpflTexture);
             return 1;
@@ -1959,7 +1959,12 @@ void flPS2VramInit() {
     }
 }
 
-LPVram *flPS2PullVramWork() {
+#if defined(TARGET_PS2)
+LPVram *flPS2PullVramWork()
+#else
+LPVram *flPS2PullVramWork(LPVram * /* unused */, s32 /* unused */)
+#endif
+{
     s32 i;
 
     for (i = 0; i < VRAM_CONTROL_SIZE; i++) {

--- a/src/anniversary/sf33rd/AcrSDK/ps2/flps2vram.c
+++ b/src/anniversary/sf33rd/AcrSDK/ps2/flps2vram.c
@@ -219,11 +219,9 @@ s32 flPS2GetTextureInfoFromContext(plContext *bits, s32 bnum, u32 th, u32 flag) 
 }
 
 s32 flPS2CreateTextureHandle(u32 th, u32 flag) {
-    FLTexture *lpflTexture;
+    FLTexture *lpflTexture = &flTexture[LO_16_BITS(th) - 1];
     u32 dma_size;
-    u32 dma_ptr;
-
-    lpflTexture = &flTexture[LO_16_BITS(th) - 1];
+    uintptr_t dma_ptr;
 
     while (1) {
         switch (flag) {
@@ -249,23 +247,25 @@ s32 flPS2CreateTextureHandle(u32 th, u32 flag) {
             break;
         }
 
-        flCTNum += 1;
-        return 1;
+        break;
     }
+
+    flCTNum += 1;
+    return 1;
 }
 
 void flPS2VramTrans(FLTexture *lpflTexture) {
-    u32 pixel_ptr;
+    uintptr_t pixel_ptr;
     u32 dma_size;
-    u32 dma_ptr;
+    uintptr_t dma_ptr;
     s32 lp0;
     s32 dw;
     s32 dh;
     s32 tex_size;
     s32 tbp;
-    u32 last_tag;
+    uintptr_t last_tag;
 
-    pixel_ptr = (u32)flPS2GetSystemBuffAdrs(lpflTexture->mem_handle);
+    pixel_ptr = (uintptr_t)flPS2GetSystemBuffAdrs(lpflTexture->mem_handle);
     dw = lpflTexture->width;
     dh = lpflTexture->height;
 
@@ -473,9 +473,9 @@ s32 flPS2GetPaletteInfoFromContext(plContext *bits, u32 ph, u32 flag) {
 }
 
 s32 flPS2CreatePaletteHandle(u32 ph, u32 flag) {
-    FLTexture *lpflPalette = &flPalette[((ph & 0xFFFF0000) >> 0x10) - 1];
+    FLTexture *lpflPalette = &flPalette[HI_16_BITS(ph) - 1];
     u32 dma_size;
-    u32 dma_ptr;
+    uintptr_t dma_ptr;
 
     while (1) {
         switch (flag) {
@@ -494,12 +494,13 @@ s32 flPS2CreatePaletteHandle(u32 ph, u32 flag) {
             }
 
             flPS2VramTrans(lpflPalette);
-            dma_ptr = flPS2VIF1CalcEndLoadImageSize(lpflPalette->size);
-            dma_size = flPS2GetSystemTmpBuff(dma_ptr, 0x10);
-            flPS2VIF1MakeEndLoadImage(dma_size, 1U);
-            flPS2DmaAddQueue2(0, dma_size & 0x0FFFFFFF, dma_size, &flPs2VIF1Control);
+            dma_size = flPS2VIF1CalcEndLoadImageSize(lpflPalette->size);
+            dma_ptr = flPS2GetSystemTmpBuff(dma_size, 0x10);
+            flPS2VIF1MakeEndLoadImage(dma_ptr, 1);
+            flPS2DmaAddQueue2(0, dma_ptr & 0x0FFFFFFF, dma_ptr, &flPs2VIF1Control);
             break;
         }
+
         break;
     }
 
@@ -617,7 +618,7 @@ s32 flPS2LockTexture(Rect * /* unused */, FLTexture *lpflTexture, plContext *lpc
         if (lpflTexture->mem_handle == 0) {
             buff_ptr1 = mflTemporaryUse(lpflTexture->size * 2);
             buff_ptr = buff_ptr1 + lpflTexture->size;
-            flPS2StoreImageB((u32)buff_ptr1,
+            flPS2StoreImageB((uintptr_t)buff_ptr1,
                              lpflTexture->size,
                              lpflTexture->tbp,
                              lpflTexture->width / 64,
@@ -631,7 +632,7 @@ s32 flPS2LockTexture(Rect * /* unused */, FLTexture *lpflTexture, plContext *lpc
             buff_ptr1 = flPS2GetSystemBuffAdrs(lpflTexture->mem_handle);
         }
 
-        lpflTexture->lock_ptr = (u32)buff_ptr;
+        lpflTexture->lock_ptr = (uintptr_t)buff_ptr;
         lpcontext->ptr = buff_ptr;
         src.desc = lpcontext->desc;
         src.width = lpcontext->width;
@@ -762,7 +763,7 @@ s32 flPS2LockTexture(Rect * /* unused */, FLTexture *lpflTexture, plContext *lpc
         buff_ptr = mflTemporaryUse(lpflTexture->size);
 
         if (lpflTexture->mem_handle == 0) {
-            flPS2StoreImageB((u32)buff_ptr,
+            flPS2StoreImageB((uintptr_t)buff_ptr,
                              lpflTexture->size,
                              lpflTexture->tbp,
                              lpflTexture->width / 64,
@@ -776,7 +777,7 @@ s32 flPS2LockTexture(Rect * /* unused */, FLTexture *lpflTexture, plContext *lpc
             flMemcpy(buff_ptr, buff_ptr1, lpflTexture->size);
         }
 
-        lpflTexture->lock_ptr = (u32)buff_ptr;
+        lpflTexture->lock_ptr = (uintptr_t)buff_ptr;
         lpcontext->ptr = buff_ptr;
 
         switch (lpflTexture->format) {
@@ -859,7 +860,7 @@ s32 flPS2LockTexture(Rect * /* unused */, FLTexture *lpflTexture, plContext *lpc
             buff_ptr = flPS2GetSystemBuffAdrs(lpflTexture->mem_handle);
         }
 
-        lpflTexture->lock_ptr = (u32)buff_ptr;
+        lpflTexture->lock_ptr = (uintptr_t)buff_ptr;
         lpcontext->ptr = buff_ptr;
 
         switch (lpflTexture->format) {
@@ -942,7 +943,7 @@ s32 flPS2LockTexture(Rect * /* unused */, FLTexture *lpflTexture, plContext *lpc
             buff_ptr = flPS2GetSystemBuffAdrs(lpflTexture->mem_handle);
         }
 
-        lpflTexture->lock_ptr = (u32)buff_ptr;
+        lpflTexture->lock_ptr = (uintptr_t)buff_ptr;
         lpcontext->ptr = buff_ptr;
 
         switch (lpflTexture->format) {
@@ -1052,14 +1053,14 @@ s32 flUnlockPalette(u32 th) {
 }
 
 s32 flPS2UnlockTexture(FLTexture *lpflTexture) {
-    u32 trans_ptr;
+    uintptr_t trans_ptr;
     u8 *buff_ptr;
     u8 *buff_ptr1;
     plContext src;
     plContext dst;
     u32 dma_size;
-    u32 dma_ptr;
-    u32 last_tag;
+    uintptr_t dma_ptr;
+    uintptr_t last_tag;
 
     trans_ptr = NULL;
 
@@ -1068,11 +1069,11 @@ s32 flPS2UnlockTexture(FLTexture *lpflTexture) {
         if (lpflTexture->mem_handle != 0) {
             buff_ptr = flPS2GetSystemBuffAdrs(lpflTexture->mem_handle);
             buff_ptr1 = (u8 *)lpflTexture->lock_ptr;
-            trans_ptr = (u32)buff_ptr;
+            trans_ptr = (uintptr_t)buff_ptr;
         } else {
             buff_ptr = mflTemporaryUse(lpflTexture->size);
             buff_ptr1 = (u8 *)lpflTexture->lock_ptr;
-            trans_ptr = (u32)buff_ptr;
+            trans_ptr = (uintptr_t)buff_ptr;
         }
 
         src.desc = lpflTexture->desc;
@@ -1202,10 +1203,10 @@ s32 flPS2UnlockTexture(FLTexture *lpflTexture) {
             buff_ptr = flPS2GetSystemBuffAdrs(lpflTexture->mem_handle);
             buff_ptr1 = (u8 *)lpflTexture->lock_ptr;
             flMemcpy(buff_ptr, buff_ptr1, lpflTexture->size);
-            trans_ptr = (u32)buff_ptr;
+            trans_ptr = (uintptr_t)buff_ptr;
         } else {
             buff_ptr = (u8 *)lpflTexture->lock_ptr;
-            trans_ptr = (u32)buff_ptr;
+            trans_ptr = (uintptr_t)buff_ptr;
         }
 
         break;
@@ -1279,7 +1280,7 @@ s32 flPS2ReloadTexture(s32 count, u32 *texlist) {
     s32 i;
     s32 j;
     u32 dma_size;
-    u32 dma_ptr;
+    uintptr_t dma_ptr;
     s32 trans_ctr;
 
     lpflKeep = NULL;
@@ -1976,7 +1977,7 @@ void flPS2PushVramWork(LPVram *lpVram) {
     LPVram *lpChild = (LPVram *)lpVram->child;
 
     if (lpParent != 0) {
-        lpParent->child = (u32)lpChild;
+        lpParent->child = (uintptr_t)lpChild;
     } else if (lpChild != 0) {
         flVramList = (LPVram *)lpChild;
     } else {
@@ -1984,7 +1985,7 @@ void flPS2PushVramWork(LPVram *lpVram) {
     }
 
     if (lpChild != 0) {
-        lpChild->parent = (u32)lpParent;
+        lpChild->parent = (uintptr_t)lpParent;
     }
 
     if (lpVram->tex_ptr != NULL) {
@@ -2002,7 +2003,7 @@ void flPS2ChainVramWork(LPVram *lpParent, LPVram *lpVram) {
 
     if (lpParent != NULL) {
         lpChild = (LPVram *)lpParent->child;
-        lpParent->child = (u32)lpVram;
+        lpParent->child = (uintptr_t)lpVram;
     } else if (flVramList == NULL) {
         flVramList = lpVram;
     } else {
@@ -2010,11 +2011,11 @@ void flPS2ChainVramWork(LPVram *lpParent, LPVram *lpVram) {
         flVramList = lpVram;
     }
 
-    lpVram->parent = (u32)lpParent;
-    lpVram->child = (u32)lpChild;
+    lpVram->parent = (uintptr_t)lpParent;
+    lpVram->child = (uintptr_t)lpChild;
 
     if (lpChild != 0) {
-        lpChild->parent = (u32)lpVram;
+        lpChild->parent = (uintptr_t)lpVram;
     }
 }
 

--- a/src/anniversary/sf33rd/AcrSDK/ps2/foundaps2.c
+++ b/src/anniversary/sf33rd/AcrSDK/ps2/foundaps2.c
@@ -141,9 +141,11 @@ s32 flInitialize(s32 /* unused */, s32 /* unused */) {
         return 0;
     }
 
+#if defined(TARGET_PS2)
     if (system_hard_init() == 0) {
         return 0;
     }
+#endif
 
     flPS2SystemTmpBuffInit();
     flPs2State.FrameCount = 0;
@@ -181,7 +183,7 @@ s32 system_work_init() {
     fmsInitialize(&flFMS, temp, 0x01800000, 0x40);
     flPs2State.system_memory_size = 0xA00000;
     temp = flAllocMemoryS(flPs2State.system_memory_size);
-    flPs2State.system_memory_start = (u32)temp;
+    flPs2State.system_memory_start = (uintptr_t)temp;
     mflInit(temp, flPs2State.system_memory_size, 0x40);
 
     plmalloc = flAllocMemory;
@@ -541,8 +543,8 @@ void flPS2InitRenderBuff(u32 fbdepth, u32 zbdepth, u32 inter_mode, u32 video_mod
     db1 = &flPs2Db[1];
     qwc = 9;
 
-    flPS2DmaAddEndTag((u32)db0, qwc, 0, 0);
-    flPS2DmaAddEndTag((u32)db1, qwc, 0, 0);
+    flPS2DmaAddEndTag((uintptr_t)db0, qwc, 0, 0);
+    flPS2DmaAddEndTag((uintptr_t)db1, qwc, 0, 0);
 
     qwc -= 1;
     db0->giftag.I64[0] = SCE_GIF_SET_TAG(qwc, 1, 0, 0, 0, 1);
@@ -591,7 +593,7 @@ void flPS2InitRenderBuff(u32 fbdepth, u32 zbdepth, u32 inter_mode, u32 video_mod
 
     ds = &flPs2DrawStart;
     qwc = 19;
-    flPS2DmaAddEndTag((u32)ds, qwc, 1, 0);
+    flPS2DmaAddEndTag((uintptr_t)ds, qwc, 1, 0);
 
     ds->dmatag.I32[2] = 0x13000000;
     ds->dmatag.I32[3] = qwc | 0x51000000;
@@ -750,7 +752,7 @@ void flPS2DrawPreparation() {
 
     dst = (u32 *)flPS2GetSystemTmpBuff(sizeof(FLPS2DrawStart), 0x10);
     flPS2_Mem_move16_16A(ds, dst, 0x14);
-    flPS2DmaAddQueue2(0, (u32)dst & 0xFFFFFFF, (u32)dst, &flPs2VIF1Control);
+    flPS2DmaAddQueue2(0, (uintptr_t)dst & 0xFFFFFFF, (uintptr_t)dst, &flPs2VIF1Control);
 }
 
 s32 flLogOut(s8 *format, ...) {

--- a/src/anniversary/sf33rd/Source/Common/MemMan.c
+++ b/src/anniversary/sf33rd/Source/Common/MemMan.c
@@ -12,12 +12,12 @@ void mmHeapInitialize(_MEMMAN_OBJ *mmobj, u8 *adrs, s32 size, s32 unit, s8 *form
     mmobj->oriSize = size;
     mmobj->ownUnit = unit;
     mmobj->ownNumber = mmInitialNumber++;
-    mmobj->memHead = (u8 *)mmRoundUp(mmobj->ownUnit, (u32)adrs);
-    mmobj->memSize = mmRoundOff(mmobj->ownUnit, (u32)adrs + size) - (u32)mmobj->memHead;
+    mmobj->memHead = (u8 *)mmRoundUp(mmobj->ownUnit, (uintptr_t)adrs);
+    mmobj->memSize = mmRoundOff(mmobj->ownUnit, (uintptr_t)adrs + size) - (uintptr_t)mmobj->memHead;
     mmobj->remainder = mmobj->memSize - (mmobj->ownUnit * 2);
     mmobj->remainderMin = mmobj->remainder;
     mmobj->cell_1st = (struct _MEMMAN_CELL *)mmobj->memHead;
-    mmobj->cell_fin = (struct _MEMMAN_CELL *)((u32)&mmobj->memHead[mmobj->memSize] - mmobj->ownUnit);
+    mmobj->cell_fin = (struct _MEMMAN_CELL *)((uintptr_t)&mmobj->memHead[mmobj->memSize] - mmobj->ownUnit);
     mmobj->cell_1st->prev = NULL;
     mmobj->cell_1st->next = mmobj->cell_fin;
     mmobj->cell_1st->size = mmobj->ownUnit;
@@ -26,11 +26,11 @@ void mmHeapInitialize(_MEMMAN_OBJ *mmobj, u8 *adrs, s32 size, s32 unit, s8 *form
     mmobj->cell_fin->size = mmobj->ownUnit;
 }
 
-u32 mmRoundUp(s32 unit, u32 num) {
+uintptr_t mmRoundUp(s32 unit, uintptr_t num) {
     return ~(unit - 1) & (num + unit - 1);
 }
 
-u32 mmRoundOff(s32 unit, u32 num) {
+uintptr_t mmRoundOff(s32 unit, uintptr_t num) {
     return num & ~(unit - 1);
 }
 
@@ -38,15 +38,15 @@ void mmDebWriteTag(s8 * /* unused */) {
     // Do nothing
 }
 
-s32 mmGetRemainder(_MEMMAN_OBJ *mmobj) {
+ssize_t mmGetRemainder(_MEMMAN_OBJ *mmobj) {
     return mmobj->remainder;
 }
 
-s32 mmGetRemainderMin(_MEMMAN_OBJ *mmobj) {
+ssize_t mmGetRemainderMin(_MEMMAN_OBJ *mmobj) {
     return mmobj->remainderMin;
 }
 
-u8 *mmAlloc(_MEMMAN_OBJ *mmobj, s32 size, s32 flag) {
+u8 *mmAlloc(_MEMMAN_OBJ *mmobj, ssize_t size, s32 flag) {
     struct _MEMMAN_CELL *cell = mmAllocSub(mmobj, size, flag);
 
     if (cell == NULL) {
@@ -62,15 +62,15 @@ u8 *mmAlloc(_MEMMAN_OBJ *mmobj, s32 size, s32 flag) {
     return (u8 *)cell + mmobj->ownUnit;
 }
 
-struct _MEMMAN_CELL *mmAllocSub(_MEMMAN_OBJ *mmobj, s32 size, s32 flag) {
+struct _MEMMAN_CELL *mmAllocSub(_MEMMAN_OBJ *mmobj, ssize_t size, s32 flag) {
     struct _MEMMAN_CELL *myself;
     struct _MEMMAN_CELL *next;
     struct _MEMMAN_CELL *cell;
-    s32 sizeTrue;
-    s32 gap;
-    s32 gapMin;
+    ssize_t sizeTrue;
+    ptrdiff_t gap;
+    ptrdiff_t gapMin;
 
-    sizeTrue = mmobj->ownUnit + mmRoundUp(mmobj->ownUnit, (u32)size);
+    sizeTrue = mmobj->ownUnit + mmRoundUp(mmobj->ownUnit, size);
     gapMin = 0x7FFFFFFF;
     cell = NULL;
 
@@ -79,7 +79,7 @@ struct _MEMMAN_CELL *mmAllocSub(_MEMMAN_OBJ *mmobj, s32 size, s32 flag) {
 
         do {
             next = myself->next;
-            gap = (u32)next - (u32)myself - myself->size;
+            gap = (intptr_t)next - (intptr_t)myself - myself->size;
 
             if (gap >= sizeTrue) {
                 if (gap == sizeTrue) {
@@ -100,7 +100,7 @@ struct _MEMMAN_CELL *mmAllocSub(_MEMMAN_OBJ *mmobj, s32 size, s32 flag) {
             return NULL;
         }
 
-        myself = (struct _MEMMAN_CELL *)((u32)cell + cell->size);
+        myself = (struct _MEMMAN_CELL *)((uintptr_t)cell + cell->size);
         myself->prev = cell;
         myself->next = cell->next;
         myself->size = sizeTrue;
@@ -113,7 +113,7 @@ struct _MEMMAN_CELL *mmAllocSub(_MEMMAN_OBJ *mmobj, s32 size, s32 flag) {
 
     do {
         next = myself->prev;
-        gap = (u32)myself - (u32)next - next->size;
+        gap = (intptr_t)myself - (intptr_t)next - next->size;
 
         if (gap >= sizeTrue) {
             if (gap == sizeTrue) {
@@ -134,7 +134,7 @@ struct _MEMMAN_CELL *mmAllocSub(_MEMMAN_OBJ *mmobj, s32 size, s32 flag) {
         return NULL;
     }
 
-    myself = (struct _MEMMAN_CELL *)((u32)cell - sizeTrue);
+    myself = (struct _MEMMAN_CELL *)((uintptr_t)cell - sizeTrue);
     myself->prev = cell->prev;
     myself->next = cell;
     myself->size = sizeTrue;
@@ -147,7 +147,7 @@ void mmFree(_MEMMAN_OBJ *mmobj, u8 *adrs) {
     struct _MEMMAN_CELL *cell;
 
     if (adrs != NULL) {
-        cell = (struct _MEMMAN_CELL *)((s32)adrs - mmobj->ownUnit);
+        cell = (struct _MEMMAN_CELL *)((intptr_t)adrs - mmobj->ownUnit);
         mmobj->remainder += cell->size;
         cell->prev->next = cell->next;
         cell->next->prev = cell->prev;

--- a/src/anniversary/sf33rd/Source/Common/PPGFile.c
+++ b/src/anniversary/sf33rd/Source/Common/PPGFile.c
@@ -403,11 +403,11 @@ s32 ppgWriteQuadUseTrans(Vertex *pos, u32 col, PPGDataList *tb, s32 tix, s32 cix
     return 1;
 }
 
-s32 ppgDecompress(s32 koCmpr, void *srcAdrs, s32 srcSize, void *dstAdrs, s32 dstSize) {
+ssize_t ppgDecompress(s32 koCmpr, void *srcAdrs, s32 srcSize, void *dstAdrs, s32 dstSize) {
     u8 *src;
     u8 *dst;
     s32 i;
-    s32 rnum = 0;
+    ssize_t rnum = 0;
 
     switch (koCmpr) {
     default:
@@ -961,7 +961,7 @@ s32 ppgRenewTexChunkSeqs(Texture *tch) {
     return 1;
 }
 
-s32 ppgSetupTexChunk_1st(Texture *tch, u8 *adrs, s32 size, s32 ixNum1st, s32 ixNums, s32 ar, s32 arcnt) {
+s32 ppgSetupTexChunk_1st(Texture *tch, u8 *adrs, ssize_t size, s32 ixNum1st, s32 ixNums, s32 ar, s32 arcnt) {
     PPGFileHeader *ppg;
     s32 i;
     s32 ofs;

--- a/src/anniversary/sf33rd/Source/Compress/zlibApp.c
+++ b/src/anniversary/sf33rd/Source/Compress/zlibApp.c
@@ -46,7 +46,7 @@ void zlib_Free(void *opaque, void *adrs) {
     mmFree(&zlib.mobj, (u8 *)adrs);
 }
 
-s32 zlib_Decompress(void *srcBuff, s32 srcSize, void *dstBuff, s32 dstSize) {
+ssize_t zlib_Decompress(void *srcBuff, s32 srcSize, void *dstBuff, s32 dstSize) {
     zlib.info.next_in = srcBuff;
     zlib.info.avail_in = srcSize;
     zlib.info.next_out = dstBuff;

--- a/src/anniversary/sf33rd/Source/Game/CHARSET.c
+++ b/src/anniversary/sf33rd/Source/Game/CHARSET.c
@@ -1419,7 +1419,7 @@ INCLUDE_ASM("asm/anniversary/nonmatchings/sf33rd/Source/Game/CHARSET", check_cgd
 
 void set_new_attnum(WORK *wk) {
     s16 aag_sw;
-    u32 dspadrs;
+    uintptr_t dspadrs;
     static u16 att_req;
 
     wk->renew_attack = wk->cg_att_ix;
@@ -1446,7 +1446,7 @@ void set_new_attnum(WORK *wk) {
     }
 
     wk->att = *(wk->att_ix_table + wk->cg_att_ix);
-    dspadrs = (u32)(wk->att_ix_table + wk->cg_att_ix);
+    dspadrs = (uintptr_t)(wk->att_ix_table + wk->cg_att_ix);
     wk->zu_flag = wk->att.level & 0x80;
     wk->jump_att_flag = wk->att.level & 0x40;
     wk->at_attribute = (wk->att.level >> 4) & 3;

--- a/src/anniversary/sf33rd/Source/Game/CHARSET.c
+++ b/src/anniversary/sf33rd/Source/Game/CHARSET.c
@@ -1424,9 +1424,14 @@ void set_new_attnum(WORK *wk) {
 
     wk->renew_attack = wk->cg_att_ix;
 
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wunsequenced"
+
     if ((att_req = (++att_req & 0x7FFF)) == 0) {
         att_req++;
     }
+
+    #pragma clang diagnostic pop
 
     aag_sw = 0;
 

--- a/src/anniversary/sf33rd/Source/Game/Continue.c
+++ b/src/anniversary/sf33rd/Source/Game/Continue.c
@@ -84,7 +84,7 @@ void Continue_2nd() {
 }
 
 void Continue_3rd() {
-    if (Cont_Timer = Check_Exit_Continue()) {
+    if ((Cont_Timer = Check_Exit_Continue())) {
         Cont_No[0] += 1;
     }
 }

--- a/src/anniversary/sf33rd/Source/Game/DC_Ghost.c
+++ b/src/anniversary/sf33rd/Source/Game/DC_Ghost.c
@@ -20,9 +20,9 @@ typedef struct {
 typedef struct {
     // total size: 0x3C
     Vec3 v[4]; // offset 0x0, size 0x30
-    u32 col;    // offset 0x30, size 0x4
-    u32 type;   // offset 0x34, size 0x4
-    s32 next;   // offset 0x38, size 0x4
+    u32 col;   // offset 0x30, size 0x4
+    u32 type;  // offset 0x34, size 0x4
+    s32 next;  // offset 0x38, size 0x4
 } NJDP2D_PRIM;
 
 typedef struct {

--- a/src/anniversary/sf33rd/Source/Game/MTRANS.c
+++ b/src/anniversary/sf33rd/Source/Game/MTRANS.c
@@ -106,7 +106,7 @@ static void lz_ext_p6_cx(u8 *srcptr, u16 *dstptr, u32 len, u16 *palptr);
 static u16 x16_mapping_set(PatternMap *map, s32 code);
 static u16 x32_mapping_set(PatternMap *map, s32 code);
 
-static void search_trsptr(u32 trstbl, s32 i, s32 n, s32 cods, s32 atrs, s32 codd, s32 atrd) {
+static void search_trsptr(uintptr_t trstbl, s32 i, s32 n, s32 cods, s32 atrs, s32 codd, s32 atrd) {
     s32 j;
     u16 *tmpbas;
     s32 ctemp;
@@ -425,7 +425,7 @@ void mlt_obj_trans_ext(MultiTexture *mt, WORK *wk, s32 base_y) {
                     y += trsptr->y;
                 }
 
-                texptr = (TEX *)((u32)textbl + ((u32 *)textbl)[trsptr->code]);
+                texptr = (TEX *)((uintptr_t)textbl + ((u32 *)textbl)[trsptr->code]);
                 dw = (texptr->wh & 0xE0) >> 2;
                 dh = (texptr->wh & 0x1C) * 2;
                 wh = (texptr->wh & 3) + 1;
@@ -520,7 +520,7 @@ void mlt_obj_trans_ext(MultiTexture *mt, WORK *wk, s32 base_y) {
                 y += trsptr->y;
             }
 
-            texptr = (TEX *)((u32)textbl + ((u32 *)textbl)[trsptr->code]);
+            texptr = (TEX *)((uintptr_t)textbl + ((u32 *)textbl)[trsptr->code]);
             dw = (texptr->wh & 0xE0) >> 2;
             dh = (texptr->wh & 0x1C) * 2;
             wh = (texptr->wh & 3) + 1;
@@ -650,7 +650,7 @@ void mlt_obj_trans(MultiTexture *mt, WORK *wk, s32 base_y) {
             y += trsptr->y;
         }
 
-        texptr = (TEX *)((u32)textbl + ((u32 *)textbl)[trsptr->code]);
+        texptr = (TEX *)((uintptr_t)textbl + ((u32 *)textbl)[trsptr->code]);
         dw = (texptr->wh & 0xE0) >> 2;
         dh = (texptr->wh & 0x1C) * 2;
         wh = (texptr->wh & 3) + 1;
@@ -802,7 +802,7 @@ void mlt_obj_trans_cp3_ext(MultiTexture *mt, WORK *wk, s32 base_y) {
                     y += trsptr->y;
                 }
 
-                texptr = (TEX *)((u32)textbl + ((u32 *)textbl)[trsptr->code]);
+                texptr = (TEX *)((uintptr_t)textbl + ((u32 *)textbl)[trsptr->code]);
                 dw = (texptr->wh & 0xE0) >> 2;
                 dh = (texptr->wh & 0x1C) * 2;
                 wh = (texptr->wh & 3) + 1;
@@ -902,7 +902,7 @@ void mlt_obj_trans_cp3_ext(MultiTexture *mt, WORK *wk, s32 base_y) {
                 y += trsptr->y;
             }
 
-            texptr = (TEX *)((u32)textbl + ((u32 *)textbl)[trsptr->code]);
+            texptr = (TEX *)((uintptr_t)textbl + ((u32 *)textbl)[trsptr->code]);
             dw = (texptr->wh & 0xE0) >> 2;
             dh = (texptr->wh & 0x1C) * 2;
             wh = (texptr->wh & 3) + 1;
@@ -1037,7 +1037,7 @@ void mlt_obj_trans_cp3(MultiTexture *mt, WORK *wk, s32 base_y) {
             y += trsptr->y;
         }
 
-        texptr = (TEX *)((u32)textbl + ((u32 *)textbl)[trsptr->code]);
+        texptr = (TEX *)((uintptr_t)textbl + ((u32 *)textbl)[trsptr->code]);
         dw = (s32)(texptr->wh & 0xE0) >> 2;
         dh = (texptr->wh & 0x1C) * 2;
         wh = (texptr->wh & 3) + 1;
@@ -1194,7 +1194,7 @@ void mlt_obj_trans_rgb_ext(MultiTexture *mt, WORK *wk, s32 base_y) {
                     y += trsptr->y;
                 }
 
-                texptr = (TEX *)((u32)textbl + ((u32 *)textbl)[trsptr->code]);
+                texptr = (TEX *)((uintptr_t)textbl + ((u32 *)textbl)[trsptr->code]);
                 dw = (texptr->wh & 0xE0) >> 2;
                 dh = (texptr->wh & 0x1C) * 2;
                 wh = (texptr->wh & 3) + 1;
@@ -1283,7 +1283,7 @@ void mlt_obj_trans_rgb_ext(MultiTexture *mt, WORK *wk, s32 base_y) {
                 y += trsptr->y;
             }
 
-            texptr = (TEX *)((u32)textbl + ((u32 *)textbl)[trsptr->code]);
+            texptr = (TEX *)((uintptr_t)textbl + ((u32 *)textbl)[trsptr->code]);
             dw = (texptr->wh & 0xE0) >> 2;
             dh = (texptr->wh & 0x1C) * 2;
             wh = (texptr->wh & 3) + 1;
@@ -1411,7 +1411,7 @@ void mlt_obj_trans_rgb(MultiTexture *mt, WORK *wk, s32 base_y) {
             y += trsptr->y;
         }
 
-        texptr = (TEX *)((u32)textbl + ((u32 *)textbl)[trsptr->code]);
+        texptr = (TEX *)((uintptr_t)textbl + ((u32 *)textbl)[trsptr->code]);
         dw = (texptr->wh & 0xE0) >> 2;
         dh = (texptr->wh & 0x1C) * 2;
         wh = (texptr->wh & 3) + 1;
@@ -2144,7 +2144,7 @@ void mlt_obj_melt2(MultiTexture *mt, u16 cg_number) {
             attr = trsptr->attr;
 
             if (!(attr & 0x1000)) {
-                texptr = (TEX *)((u32)textbl + ((u32 *)textbl)[trsptr->code]);
+                texptr = (TEX *)((uintptr_t)textbl + ((u32 *)textbl)[trsptr->code]);
                 dd = (((texptr->wh & 0xE0) << 5) - 0x400) | (((texptr->wh & 0x1C) << 6) - 0x100);
                 wh = (texptr->wh & 3) + 1;
                 size = (wh * wh) << 6;

--- a/src/anniversary/sf33rd/Source/Game/MTRANS.c
+++ b/src/anniversary/sf33rd/Source/Game/MTRANS.c
@@ -471,7 +471,7 @@ void mlt_obj_trans_ext(MultiTexture *mt, WORK *wk, s32 base_y) {
                                          dh,
                                          mt->mltgidx32,
                                          code,
-                                         palo | ((trsptr->attr ^ attr) & 0xC000 | 0x2000),
+                                         palo | (((trsptr->attr ^ attr) & 0xC000) | 0x2000),
                                          wk->my_clear_level,
                                          mt->id);
                     break;
@@ -560,7 +560,7 @@ void mlt_obj_trans_ext(MultiTexture *mt, WORK *wk, s32 base_y) {
                                      dh,
                                      mt->mltgidx32,
                                      code,
-                                     palo | ((trsptr->attr ^ attr) & 0xC000 | 0x2000),
+                                     palo | (((trsptr->attr ^ attr) & 0xC000) | 0x2000),
                                      wk->my_clear_level,
                                      mt->id);
                 break;

--- a/src/anniversary/sf33rd/Source/Game/OPENING.c
+++ b/src/anniversary/sf33rd/Source/Game/OPENING.c
@@ -195,7 +195,7 @@ s16 TITLE_Move(u16 type) {
 
 void OPBG_Init() {
     void *loadAdrs;
-    u32 loadSize;
+    size_t loadSize;
     s16 i;
     s16 key;
 

--- a/src/anniversary/sf33rd/Source/Game/RAMCNT.c
+++ b/src/anniversary/sf33rd/Source/Game/RAMCNT.c
@@ -48,30 +48,32 @@ void Init_ram_control_work(u8 *adrs, s32 size) {
 }
 
 void Push_ramcnt_key(s16 key) {
-    RCKeyWork *rwk;
+    RCKeyWork *rwk = &rckey_work[key];
 
-    rwk = &rckey_work[key];
     if (rwk->use != 0) {
         if ((rwk->type == 8) || (rwk->type == 9)) {
             flLogOut("TEXCASH KEY PUSH ERROR\n");
             ERR_STOP;
         }
+
         Push_ramcnt_key_original_2(key);
     }
+
     return;
 }
 
 void Push_ramcnt_key_original(s16 key) {
-    RCKeyWork *rwk;
+    RCKeyWork *rwk = &rckey_work[key];
 
-    rwk = &rckey_work[key];
     if (rwk->use != 0) {
         if ((rwk->type != 8) && (rwk->type != 9)) {
             flLogOut("TEXCASH KEY PUSH ERROR2\n");
             ERR_STOP;
         }
+
         Push_ramcnt_key_original_2(key);
     }
+
     return;
 }
 
@@ -80,16 +82,17 @@ void Push_ramcnt_key_original_2(s16 key) {
     void purge_texture_group(u16 grp);
 #endif
 
-    RCKeyWork *rwk;
+    RCKeyWork *rwk = &rckey_work[key];
 
-    rwk = &rckey_work[key];
     if (rwk->use != 0) {
         mmFree(&rckey_mmobj, (u8 *)rwk->adr);
         rwk->type = 0;
         rwk->use = 0;
+
         if (rwk->group_num) {
             purge_texture_group(rwk->group_num);
         }
+
         rwk->group_num = 0;
         rckeyque[rckeyctr++] = key;
     }
@@ -101,6 +104,7 @@ void Purge_memory_of_kind_of_key(u8 kokey) {
 
     for (i = 0; i < RCKEY_WORK_MAX; i++) {
         rwk = &rckey_work[i];
+
         if (rwk->use && (rwk->type == kokey)) {
             Push_ramcnt_key(i);
         }
@@ -113,34 +117,39 @@ void Set_size_data_ramcnt_key(s16 key, u32 size) {
         flLogOut("未使用のメモリキーへファイルサイズを格納しようとしました。\n");
         ERR_STOP;
     }
+
     rckey_work[key].size = size;
 }
 
-u32 Get_size_data_ramcnt_key(s16 key) {
+size_t Get_size_data_ramcnt_key(s16 key) {
     if (key <= 0) {
         // An attempt was made to get a file size from an unused memory key.\n
         flLogOut("未使用のメモリキーからファイルサイズを取得しようとしました。\n");
         ERR_STOP;
     }
+
     return rckey_work[key].size;
 }
 
-u32 Get_ramcnt_address(s16 key) {
+uintptr_t Get_ramcnt_address(s16 key) {
     if (key <= 0) {
         // An attempt was made to obtain an address from an unused memory key.\n
         flLogOut("未使用のメモリキーからアドレスを取得しようとしました。\n");
         ERR_STOP;
     }
+
     return rckey_work[key].adr;
 }
 
 s16 Search_ramcnt_type(u8 kokey) {
     s16 i;
+
     for (i = 1; i < RCKEY_WORK_MAX; i++) {
         if ((rckey_work[i].use) && (kokey == (rckey_work[i].type))) {
             return i;
         }
     }
+
     return 0;
 }
 
@@ -148,16 +157,19 @@ s32 Test_ramcnt_key(s16 key) {
     if (key == 0) {
         return 1;
     }
+
     if (rckey_work[key].use == 0) {
         return 0;
     }
+
     if (rckey_work[key].group_num != 0) {
         return 0;
     }
+
     return 1;
 }
 
-s16 Pull_ramcnt_key(u32 memreq, u8 kokey, u8 group, u8 frre) {
+s16 Pull_ramcnt_key(size_t memreq, u8 kokey, u8 group, u8 frre) {
     RCKeyWork *rwk;
     s16 key;
 
@@ -176,10 +188,12 @@ s16 Pull_ramcnt_key(u32 memreq, u8 kokey, u8 group, u8 frre) {
 
     if (memreq != 0) {
         rwk->size = memreq;
+
         if (frre != 0) {
             frre--;
         }
-        rwk->adr = (u32)mmAlloc(&rckey_mmobj, memreq, frre);
+
+        rwk->adr = (uintptr_t)mmAlloc(&rckey_mmobj, memreq, frre);
     } else {
         goto err;
     }

--- a/src/anniversary/sf33rd/Source/Game/Reset.c
+++ b/src/anniversary/sf33rd/Source/Game/Reset.c
@@ -117,7 +117,7 @@ s32 Setup_Next_Disposal() {
         return 1;
     }
 
-    if ((G_No[0] == 1) || (G_No[0] == 2) && (G_No[1] == 0)) {
+    if ((G_No[0] == 1) || ((G_No[0] == 2) && (G_No[1] == 0))) {
         return 1;
     }
 

--- a/src/anniversary/sf33rd/Source/Game/aboutspr.c
+++ b/src/anniversary/sf33rd/Source/Game/aboutspr.c
@@ -600,7 +600,7 @@ s32 sort_push_requestB(WORK *wk) {
 void shadow_setup(WORK *wk, s16 bsy) {
     f32 base_y = (f32)bsy;
 
-    njdp2d_sort(&base_y, (f32)PrioBase[wk->kage_prio], (s32)wk, 1);
+    njdp2d_sort(&base_y, (f32)PrioBase[wk->kage_prio], (u32)(uintptr_t)wk, 1);
 }
 
 void shadow_drawing(WORK *wk, s16 bsy) {

--- a/src/anniversary/sf33rd/Source/Game/debug/Debug.c
+++ b/src/anniversary/sf33rd/Source/Game/debug/Debug.c
@@ -109,7 +109,7 @@ void Debug_2nd(struct _TASK *task_ptr) {
     flPrintL(1, 1, "[DEBUG MODE]");
     flPrintL(14, 1, (s8 *)debug_name_data[Debug_ID]);
 
-    if (sw = Debug_Menu_Shot()) {
+    if ((sw = Debug_Menu_Shot())) {
         if (sw == 256) {
             Debug_w[Debug_Index] = 0;
         }

--- a/src/anniversary/sf33rd/Source/Game/menu.c
+++ b/src/anniversary/sf33rd/Source/Game/menu.c
@@ -2436,7 +2436,7 @@ void Sound_Test(struct _TASK *task_ptr) {
             }
         }
 
-        if (IO_Result == 0x200 || (Menu_Cursor_Y[0] == 6) && (IO_Result == 0x100 || IO_Result == 0x4000)) {
+        if (IO_Result == 0x200 || ((Menu_Cursor_Y[0] == 6) && (IO_Result == 0x100 || IO_Result == 0x4000))) {
             SE_selected();
             Return_Option_Mode_Sub(task_ptr);
             setupAlwaysSeamlessFlag(0);

--- a/src/anniversary/sf33rd/Source/Game/texcash.c
+++ b/src/anniversary/sf33rd/Source/Game/texcash.c
@@ -199,7 +199,7 @@ void make_texcash_work(s16 ix) {
         mts[ix].mltcshtime16 = mts_base[ix].life16;
         mts[ix].mltcshtime32 = mts_base[ix].life32;
 
-        if (mts[ix].ext = (mts_base[ix].mode & 0x2000) != 0) {
+        if ((mts[ix].ext = ((mts_base[ix].mode & 0x2000) != 0))) {
             memreq = (mts[ix].mltnum16 * 8) + (mts[ix].mltnum32 * 8) + sizeof(PatternCollection) +
                      sizeof(TexturePoolFree) + sizeof(TexturePoolUsed);
             mts_ok[ix].key0 = Pull_ramcnt_key(memreq, mts_base[ix].type, 0, 0);

--- a/src/anniversary/sf33rd/Source/Game/texcash.c
+++ b/src/anniversary/sf33rd/Source/Game/texcash.c
@@ -161,9 +161,12 @@ void make_texcash_work(s16 ix) {
     void init_texcash_2nd(s32 ix);
 #endif
 
-    u32 memreq;
+    size_t memreq;
     u8 *adrs;
-    u32 page16;
+    // For some reason page16 is reused later as a pointer.
+    // That's why it's uintptr_t and not u32 like page32.
+    // I guess the devs were too lazy to make another var or something.
+    uintptr_t page16;
     u32 page32;
 
     if (mts_ok[ix].be) {
@@ -188,11 +191,11 @@ void make_texcash_work(s16 ix) {
             page32 = mts_base[ix].p32;
         }
 
-        mts[ix].mltnum16 = page16 << 8;
+        mts[ix].mltnum16 = (u32)page16 << 8;
         mts[ix].mltnum32 = page32 << 6;
-        mts[ix].mltnum = page16 + page32;
+        mts[ix].mltnum = (u32)page16 + page32;
         mts[ix].mltgidx16 = mts_base[ix].gix;
-        mts[ix].mltgidx32 = page16 + mts_base[ix].gix;
+        mts[ix].mltgidx32 = (u32)page16 + mts_base[ix].gix;
         mts[ix].mltcshtime16 = mts_base[ix].life16;
         mts[ix].mltcshtime32 = mts_base[ix].life32;
 

--- a/src/anniversary/sf33rd/Source/Game/texgroup.c
+++ b/src/anniversary/sf33rd/Source/Game/texgroup.c
@@ -129,8 +129,8 @@ void q_ldreq_texture_group(REQ *curr) {
     const TexGroupData *bsd;
     CharInitData *cit;
     CharInitData *cit2;
-    u32 ldadr;
-    u32 ldchd;
+    uintptr_t ldadr;
+    uintptr_t ldchd;
     s32 err;
     s16 i;
     u32 *patchAdrs;
@@ -250,8 +250,9 @@ void q_ldreq_texture_group(REQ *curr) {
             case 1:
                 ldchd = ldadr + bsd->to_chd;
 
+                // 25 is the number of members in CharInitData struct
                 for (i = 0; i < 25; i++) {
-                    ((u32 *)ldchd)[i] += ldchd;
+                    ((uintptr_t *)ldchd)[i] += ldchd;
                 }
 
                 cit = (CharInitData *)ldchd;
@@ -332,7 +333,7 @@ void reservMemKeySelObj() {
 void checkSelObjFileLoaded() {
     const TexGroupData *bsd;
     TEX_GRP_LD *lds;
-    u32 ldadr;
+    uintptr_t ldadr;
     s32 rnum;
 
     if (omSelObjNowOnMemoryType == mpp_w.language) {
@@ -416,7 +417,7 @@ s32 load_any_texture_patnum(u16 patnum, u8 kokey, u8 _unused) {
 s32 load_any_texture_grpnum(u8 grp, u8 kokey) {
     const TexGroupData *bsd;
     TEX_GRP_LD *lds;
-    u32 ldadr;
+    uintptr_t ldadr;
 
     if (grp == 0) {
         return 0;

--- a/src/anniversary/sf33rd/Source/PS2/mc/knjsub.c
+++ b/src/anniversary/sf33rd/Source/PS2/mc/knjsub.c
@@ -5,7 +5,7 @@
 INCLUDE_RODATA("asm/anniversary/nonmatchings/sf33rd/Source/PS2/mc/knjsub", literal_225_005601F0);
 INCLUDE_ASM("asm/anniversary/nonmatchings/sf33rd/Source/PS2/mc/knjsub", KnjInit);
 #else
-void KnjInit(u32 type, u32 adrs, u32 disp_max, u32 top_dbp) {
+void KnjInit(u32 type, uintptr_t adrs, u32 disp_max, u32 top_dbp) {
     not_implemented(__func__);
 }
 #endif

--- a/src/anniversary/sf33rd/Source/PS2/mc/mcsub.c
+++ b/src/anniversary/sf33rd/Source/PS2/mc/mcsub.c
@@ -1062,8 +1062,8 @@ void McActSaveSet(s32 port, void *bufs) {
     mw->port = port;
     sprintf(mw->path, "%s/%s", mw->dir, mw->dir);
     mw->size = mf->file[4].size;
-    mf->file[4].bufs = (s32)bufs;
-    mf->file[5].bufs = (s32)bufs + mw->size;
+    mf->file[4].bufs = (intptr_t)bufs;
+    mf->file[5].bufs = (intptr_t)bufs + mw->size;
     mw->exe_flag = 1;
 }
 
@@ -1400,7 +1400,7 @@ s32 McActNewChk(s32 port) {
 }
 
 s32 McActAvailSet(s32 *ico) {
-    s32 top;
+    intptr_t top;
     s32 i;
     s32 n;
     s32 cluster;
@@ -1408,7 +1408,7 @@ s32 McActAvailSet(s32 *ico) {
     _memcard_file *mf = mc_file_tbl[mw->file_type];
 
     if (ico != NULL) {
-        top = (s32)ico;
+        top = (intptr_t)ico;
         ico++;
         n = (s32)*ico++;
 
@@ -1418,9 +1418,9 @@ s32 McActAvailSet(s32 *ico) {
             }
 
             if (mf->file[i].flag != 0) {
-                mf->file[i].bufs = (s32)*ico++;
+                mf->file[i].bufs = *ico++;
                 mf->file[i].bufs += top;
-                mf->file[i].size = (s32)*ico++;
+                mf->file[i].size = *ico++;
                 n -= 1;
             }
         }

--- a/src/anniversary/sf33rd/Source/PS2/mc/savesub.c
+++ b/src/anniversary/sf33rd/Source/PS2/mc/savesub.c
@@ -1805,7 +1805,7 @@ static s32 yes_no_check(_save_work *save) {
             break;
         }
 
-        if (((save->tr & 8) && (save->yes_no_flag == 1)) || (save->tr & 4) && (save->yes_no_flag == 2)) {
+        if (((save->tr & 8) && (save->yes_no_flag == 1)) || ((save->tr & 4) && (save->yes_no_flag == 2))) {
             save->yes_no_flag ^= 3;
             select_se();
         }

--- a/src/anniversary/sf33rd/Source/PS2/mc/savesub.c
+++ b/src/anniversary/sf33rd/Source/PS2/mc/savesub.c
@@ -101,7 +101,7 @@ static void load_data(s32 fnum, void *adrs) {
     }
 
     nsct = ADXF_GetFsizeSct(save->adxf);
-    printf("load_data: fnum=%d adrs=0x%X size=0x%X\n", fnum, (u32)adrs, nsct << 11);
+    printf("load_data: fnum=%d adrs=0x%X size=0x%X\n", fnum, (uintptr_t)adrs, nsct << 11);
     ADXF_ReadNw(save->adxf, nsct, adrs);
 }
 
@@ -127,7 +127,7 @@ static s32 load_busy_ck() {
 
 void SaveInit(s32 file_type, s32 save_mode) {
     u32 size;
-    u32 adrs;
+    uintptr_t adrs;
     _save_work *save = &SaveWork;
 
     Forbid_Reset = 1;
@@ -243,7 +243,7 @@ static void save_move_init(_save_work *save) {
             break;
         }
 
-        KnjInit(knj_type, (u32)save->fnt_adrs, 0x200, flPs2State.ZBuffAdrs);
+        KnjInit(knj_type, (uintptr_t)save->fnt_adrs, 0x200, flPs2State.ZBuffAdrs);
         load_data(icon_fnum[save->file_type], save->ico_adrs);
         save->r_no_1 += 1;
         /* fallthrough */


### PR DESCRIPTION
- Fixed most (hopefully) instances pointer truncation
- Enabled all clang warnings, disabling some of them. This'll help us write more portable code