### PR TITLE
Uncomment fatal_error around effinitjptbl callers

### DIFF
--- a/src/anniversary/sf33rd/Source/Game/CHARSET.c
+++ b/src/anniversary/sf33rd/Source/Game/CHARSET.c
@@ -899,12 +899,7 @@ s32 comm_pa_y(WORK *wk, UNK11 *ctc) {
 }
 
 s32 comm_exec(WORK *wk, UNK11 *ctc) {
-#if defined(TARGET_PS2)
     effinitjptbl[ctc->koc](wk, (u8)ctc->ix);
-#else
-    fatal_error("effinitjptbl is not decompiled.");
-#endif
-
     return 1;
 }
 
@@ -2564,11 +2559,7 @@ void check_cgd_patdat(WORK *wk) {
         }
 
         if (wk->cg_effect) {
-#if defined(TARGET_PS2)
             effinitjptbl[wk->cg_effect](wk, wk->cg_eftype);
-#else
-            fatal_error("effinitjptbl is not decompiled.");
-#endif
         }
 
         break;


### PR DESCRIPTION
Pretty straightforward change. 
Figured it might as well be the case since effmovejptbl doesn't have fatal_error around it's callers despite being incomplete itself.