### PR TITLE
Port 18

### DIFF
--- a/include/sf33rd/Source/Game/EFFECT.h
+++ b/include/sf33rd/Source/Game/EFFECT.h
@@ -6,13 +6,13 @@
 
 #define EFFECT_MAX 128
 
-extern s16 exec_tm[8];           // size: 0x10, address: 0x578F80
-extern u32 frw[EFFECT_MAX][448]; // size: 0x38000, address: 0x5A9CA0
-extern s16 head_ix[8];           // size: 0x10, address: 0x578FA0
-extern s16 tail_ix[8];           // size: 0x10, address: 0x578F90
-extern s16 frwctr_min;           // size: 0x2, address: 0x578FB0
-extern s16 frwctr;               // size: 0x2, address: 0x578FB4
-extern s16 frwque[EFFECT_MAX];   // size: 0x100, address: 0x5A9BA0
+extern s16 exec_tm[8];
+extern uintptr_t frw[EFFECT_MAX][448];
+extern s16 head_ix[8];
+extern s16 tail_ix[8];
+extern s16 frwctr_min;
+extern s16 frwctr;
+extern s16 frwque[EFFECT_MAX];
 
 void move_effect_work(s16 index);
 void disp_effect_work();

--- a/include/structs.h
+++ b/include/structs.h
@@ -748,8 +748,8 @@ typedef struct {
     s16 master_id;       // offset 0x38E, size 0x2
     s16 master_player;   // offset 0x390, size 0x2
     s16 master_priority; // offset 0x392, size 0x2
-    char look_up_flag;   // offset 0x394, size 0x1
-    char curr_ja;        // offset 0x395, size 0x1
+    s8 look_up_flag;     // offset 0x394, size 0x1
+    s8 curr_ja;          // offset 0x395, size 0x1
     u16 ja_disp_bit;     // offset 0x396, size 0x2
     u16 ja_color_bit;    // offset 0x398, size 0x2
     s16 fade_cja;        // offset 0x39A, size 0x2

--- a/include/structs.h
+++ b/include/structs.h
@@ -214,7 +214,7 @@ typedef struct {
     u8 catch_prio;   // offset 0x4, size 0x1
     u8 catch_flip;   // offset 0x5, size 0x1
     s16 catch_nix;   // offset 0x6, size 0x2
-} UNK_10;
+} CatchTable;
 
 typedef struct {
     // total size: 0x8
@@ -266,141 +266,154 @@ typedef struct {
 
 typedef struct {
     // total size: 0x388
-    s8 be_flag;              // offset 0x0, size 0x1
-    s8 disp_flag;            // offset 0x1, size 0x1
-    u8 blink_timing;         // offset 0x2, size 0x1
-    u8 operator;             // offset 0x3, size 0x1
-    u8 type;                 // offset 0x4, size 0x1
-    u8 charset_id;           // offset 0x5, size 0x1
-    s16 work_id;             // offset 0x6, size 0x2
-    s16 id;                  // offset 0x8, size 0x2
-    s8 rl_flag;              // offset 0xA, size 0x1
-    s8 rl_waza;              // offset 0xB, size 0x1
-    u32* target_adrs;        // offset 0xC, size 0x4
-    u32* hit_adrs;           // offset 0x10, size 0x4
-    u32* dmg_adrs;           // offset 0x14, size 0x4
-    s16 before;              // offset 0x18, size 0x2
-    s16 myself;              // offset 0x1A, size 0x2
-    s16 behind;              // offset 0x1C, size 0x2
-    s16 listix;              // offset 0x1E, size 0x2
-    s16 dead_f;              // offset 0x20, size 0x2
-    s16 timing;              // offset 0x22, size 0x2
-    s16 routine_no[8];       // offset 0x24, size 0x10
-    s16 old_rno[8];          // offset 0x34, size 0x10
-    s16 hit_stop;            // offset 0x44, size 0x2
-    s16 hit_quake;           // offset 0x46, size 0x2
-    s8 cgromtype;            // offset 0x48, size 0x1
-    u8 kage_flag;            // offset 0x49, size 0x1
-    s16 kage_hx;             // offset 0x4A, size 0x2
-    s16 kage_hy;             // offset 0x4C, size 0x2
-    s16 kage_prio;           // offset 0x4E, size 0x2
-    s16 kage_width;          // offset 0x50, size 0x2
-    s16 kage_char;           // offset 0x52, size 0x2
-    s16 position_x;          // offset 0x54, size 0x2
-    s16 position_y;          // offset 0x56, size 0x2
-    s16 position_z;          // offset 0x58, size 0x2
-    s16 next_x;              // offset 0x5A, size 0x2
-    s16 next_y;              // offset 0x5C, size 0x2
-    s16 next_z;              // offset 0x5E, size 0x2
-    s16 scr_mv_x;            // offset 0x60, size 0x2
-    s16 scr_mv_y;            // offset 0x62, size 0x2
-    XY xyz[3];               // offset 0x64, size 0xC
-    s16 old_pos[3];          // offset 0x70, size 0x6
-    s16 sync_suzi;           // offset 0x76, size 0x2
-    u16* suzi_offset;        // offset 0x78, size 0x4
-    MVXY mvxy;               // offset 0x7C, size 0x18
-    s16 direction;           // offset 0x94, size 0x2
-    s16 dir_old;             // offset 0x96, size 0x2
-    s16 dir_step;            // offset 0x98, size 0x2
-    s16 dir_timer;           // offset 0x9A, size 0x2
-    s16 vitality;            // offset 0x9C, size 0x2
-    s16 vital_new;           // offset 0x9E, size 0x2
-    s16 vital_old;           // offset 0xA0, size 0x2
-    s16 dm_vital;            // offset 0xA2, size 0x2
-    s16 dmcal_m;             // offset 0xA4, size 0x2
-    s16 dmcal_d;             // offset 0xA6, size 0x2
-    s8 weight_level;         // offset 0xA8, size 0x1
-    UNK11 cmoa;              // offset 0xAA, size 0x8
-    UNK11 cmsw;              // offset 0xB2, size 0x8
-    UNK11 cmlp;              // offset 0xBA, size 0x8
-    UNK11 cml2;              // offset 0xC2, size 0x8
-    UNK11 cmja;              // offset 0xCA, size 0x8
-    UNK11 cmj2;              // offset 0xD2, size 0x8
-    UNK11 cmj3;              // offset 0xDA, size 0x8
-    UNK11 cmj4;              // offset 0xE2, size 0x8
-    UNK11 cmj5;              // offset 0xEA, size 0x8
-    UNK11 cmj6;              // offset 0xF2, size 0x8
-    UNK11 cmj7;              // offset 0xFA, size 0x8
-    UNK11 cmms;              // offset 0x102, size 0x8
-    UNK11 cmmd;              // offset 0x10A, size 0x8
-    UNK11 cmyd;              // offset 0x112, size 0x8
-    UNK11 cmcf;              // offset 0x11A, size 0x8
-    UNK11 cmcr;              // offset 0x122, size 0x8
-    UNK11 cmbk;              // offset 0x12A, size 0x8
-    UNK11 cmb2;              // offset 0x132, size 0x8
-    UNK11 cmb3;              // offset 0x13A, size 0x8
-    UNK11 cmhs;              // offset 0x142, size 0x8
-    UNK11 cmr0;              // offset 0x14A, size 0x8
-    UNK11 cmr1;              // offset 0x152, size 0x8
-    UNK11 cmr2;              // offset 0x15A, size 0x8
-    UNK11 cmr3;              // offset 0x162, size 0x8
-    s16 cmwk[32];            // offset 0x16A, size 0x40
-    u32* char_table[12];     // offset 0x1AC, size 0x30
-    u32* se_random_table;    // offset 0x1DC, size 0x4
-    s16* step_xy_table;      // offset 0x1E0, size 0x4
-    s16* move_xy_table;      // offset 0x1E4, size 0x4
-    UNK_8* overlap_char_tbl; // offset 0x1E8, size 0x4
-    UNK_9* olc_ix_table;     // offset 0x1EC, size 0x4
-    UNK_9 cg_olc;            // offset 0x1F0, size 0x8
-    UNK_10* rival_catch_tbl; // offset 0x1F8, size 0x4
-    UNK_10* curr_rca;        // offset 0x1FC, size 0x4
-    u32* set_char_ad;        // offset 0x200, size 0x4
-    s16 cg_ix;               // offset 0x204, size 0x2
-    s16 now_koc;             // offset 0x206, size 0x2
-    s16 char_index;          // offset 0x208, size 0x2
-    s16 current_colcd;       // offset 0x20A, size 0x2
-    s16 cgd_type;            // offset 0x20C, size 0x2
-    u8 pat_status;           // offset 0x20E, size 0x1
-    u8 kind_of_waza;         // offset 0x20F, size 0x1
-    u8 hit_range;            // offset 0x210, size 0x1
-    u8 total_paring;         // offset 0x211, size 0x1
-    u8 total_att_set;        // offset 0x212, size 0x1
-    u8 sp_tech_id;           // offset 0x213, size 0x1
-    u8 cg_type;              // offset 0x214, size 0x1
-    u8 cg_ctr;               // offset 0x215, size 0x1
-    u16 cg_se;               // offset 0x216, size 0x2
-    u16 cg_olc_ix;           // offset 0x218, size 0x2
-    u16 cg_number;           // offset 0x21A, size 0x2
-    u16 cg_hit_ix;           // offset 0x21C, size 0x2
-    s16 cg_att_ix;           // offset 0x21E, size 0x2
-    u8 cg_extdat;            // offset 0x220, size 0x1
-    u8 cg_cancel;            // offset 0x221, size 0x1
-    u8 cg_effect;            // offset 0x222, size 0x1
-    u8 cg_eftype;            // offset 0x223, size 0x1
-    u16 cg_zoom;             // offset 0x224, size 0x2
-    u16 cg_rival;            // offset 0x226, size 0x2
-    u16 cg_add_xy;           // offset 0x228, size 0x2
-    u8 cg_next_ix;           // offset 0x22A, size 0x1
-    u8 cg_status;            // offset 0x22B, size 0x1
-    s16 cg_wca_ix;           // offset 0x22C, size 0x2
-    s16 cg_jphos;            // offset 0x22E, size 0x2
-    u16 cg_meoshi;           // offset 0x230, size 0x2
-    u8 cg_prio;              // offset 0x232, size 0x1
-    u8 cg_flip;              // offset 0x233, size 0x1
-    u16 old_cgnum;           // offset 0x234, size 0x2
-    s16 floor;               // offset 0x236, size 0x2
-    u16 ccoff;               // offset 0x238, size 0x2
-    s16 colcd;               // offset 0x23A, size 0x2
-    s16 my_col_mode;         // offset 0x23C, size 0x2
-    s16 my_col_code;         // offset 0x23E, size 0x2
-    s16 my_priority;         // offset 0x240, size 0x2
-    s16 my_family;           // offset 0x242, size 0x2
-    s16 my_ext_pri;          // offset 0x244, size 0x2
-    s16 my_bright_type;      // offset 0x246, size 0x2
-    s16 my_bright_level;     // offset 0x248, size 0x2
-    s16 my_clear_level;      // offset 0x24A, size 0x2
-    s16 my_mts;              // offset 0x24C, size 0x2
-    s16 my_mr_flag;          // offset 0x24E, size 0x2
+    s8 be_flag;       // offset 0x0, size 0x1
+    s8 disp_flag;     // offset 0x1, size 0x1
+    u8 blink_timing;  // offset 0x2, size 0x1
+    u8 operator;      // offset 0x3, size 0x1
+    u8 type;          // offset 0x4, size 0x1
+    u8 charset_id;    // offset 0x5, size 0x1
+    s16 work_id;      // offset 0x6, size 0x2
+    s16 id;           // offset 0x8, size 0x2
+    s8 rl_flag;       // offset 0xA, size 0x1
+    s8 rl_waza;       // offset 0xB, size 0x1
+    u32* target_adrs; // offset 0xC, size 0x4
+    u32* hit_adrs;    // offset 0x10, size 0x4
+    u32* dmg_adrs;    // offset 0x14, size 0x4
+
+    /// Index of the struct that is in front of this one in the list.
+    /// offset 0x18, size 0x2
+    s16 before;
+
+    /// Index of this struct.
+    /// offset 0x1A, size 0x2
+    s16 myself;
+
+    /// Index of the struct that is behind this one in the list.
+    /// offset 0x1C, size 0x2
+    s16 behind;
+
+    /// Index of the list that this struct is a part of.
+    // offset 0x1E, size 0x2
+    s16 listix;
+
+    s16 dead_f;                  // offset 0x20, size 0x2
+    s16 timing;                  // offset 0x22, size 0x2
+    s16 routine_no[8];           // offset 0x24, size 0x10
+    s16 old_rno[8];              // offset 0x34, size 0x10
+    s16 hit_stop;                // offset 0x44, size 0x2
+    s16 hit_quake;               // offset 0x46, size 0x2
+    s8 cgromtype;                // offset 0x48, size 0x1
+    u8 kage_flag;                // offset 0x49, size 0x1
+    s16 kage_hx;                 // offset 0x4A, size 0x2
+    s16 kage_hy;                 // offset 0x4C, size 0x2
+    s16 kage_prio;               // offset 0x4E, size 0x2
+    s16 kage_width;              // offset 0x50, size 0x2
+    s16 kage_char;               // offset 0x52, size 0x2
+    s16 position_x;              // offset 0x54, size 0x2
+    s16 position_y;              // offset 0x56, size 0x2
+    s16 position_z;              // offset 0x58, size 0x2
+    s16 next_x;                  // offset 0x5A, size 0x2
+    s16 next_y;                  // offset 0x5C, size 0x2
+    s16 next_z;                  // offset 0x5E, size 0x2
+    s16 scr_mv_x;                // offset 0x60, size 0x2
+    s16 scr_mv_y;                // offset 0x62, size 0x2
+    XY xyz[3];                   // offset 0x64, size 0xC
+    s16 old_pos[3];              // offset 0x70, size 0x6
+    s16 sync_suzi;               // offset 0x76, size 0x2
+    u16* suzi_offset;            // offset 0x78, size 0x4
+    MVXY mvxy;                   // offset 0x7C, size 0x18
+    s16 direction;               // offset 0x94, size 0x2
+    s16 dir_old;                 // offset 0x96, size 0x2
+    s16 dir_step;                // offset 0x98, size 0x2
+    s16 dir_timer;               // offset 0x9A, size 0x2
+    s16 vitality;                // offset 0x9C, size 0x2
+    s16 vital_new;               // offset 0x9E, size 0x2
+    s16 vital_old;               // offset 0xA0, size 0x2
+    s16 dm_vital;                // offset 0xA2, size 0x2
+    s16 dmcal_m;                 // offset 0xA4, size 0x2
+    s16 dmcal_d;                 // offset 0xA6, size 0x2
+    s8 weight_level;             // offset 0xA8, size 0x1
+    UNK11 cmoa;                  // offset 0xAA, size 0x8
+    UNK11 cmsw;                  // offset 0xB2, size 0x8
+    UNK11 cmlp;                  // offset 0xBA, size 0x8
+    UNK11 cml2;                  // offset 0xC2, size 0x8
+    UNK11 cmja;                  // offset 0xCA, size 0x8
+    UNK11 cmj2;                  // offset 0xD2, size 0x8
+    UNK11 cmj3;                  // offset 0xDA, size 0x8
+    UNK11 cmj4;                  // offset 0xE2, size 0x8
+    UNK11 cmj5;                  // offset 0xEA, size 0x8
+    UNK11 cmj6;                  // offset 0xF2, size 0x8
+    UNK11 cmj7;                  // offset 0xFA, size 0x8
+    UNK11 cmms;                  // offset 0x102, size 0x8
+    UNK11 cmmd;                  // offset 0x10A, size 0x8
+    UNK11 cmyd;                  // offset 0x112, size 0x8
+    UNK11 cmcf;                  // offset 0x11A, size 0x8
+    UNK11 cmcr;                  // offset 0x122, size 0x8
+    UNK11 cmbk;                  // offset 0x12A, size 0x8
+    UNK11 cmb2;                  // offset 0x132, size 0x8
+    UNK11 cmb3;                  // offset 0x13A, size 0x8
+    UNK11 cmhs;                  // offset 0x142, size 0x8
+    UNK11 cmr0;                  // offset 0x14A, size 0x8
+    UNK11 cmr1;                  // offset 0x152, size 0x8
+    UNK11 cmr2;                  // offset 0x15A, size 0x8
+    UNK11 cmr3;                  // offset 0x162, size 0x8
+    s16 cmwk[32];                // offset 0x16A, size 0x40
+    u32* char_table[12];         // offset 0x1AC, size 0x30
+    u32* se_random_table;        // offset 0x1DC, size 0x4
+    s16* step_xy_table;          // offset 0x1E0, size 0x4
+    s16* move_xy_table;          // offset 0x1E4, size 0x4
+    UNK_8* overlap_char_tbl;     // offset 0x1E8, size 0x4
+    UNK_9* olc_ix_table;         // offset 0x1EC, size 0x4
+    UNK_9 cg_olc;                // offset 0x1F0, size 0x8
+    CatchTable* rival_catch_tbl; // offset 0x1F8, size 0x4
+    CatchTable* curr_rca;        // offset 0x1FC, size 0x4
+    u32* set_char_ad;            // offset 0x200, size 0x4
+    s16 cg_ix;                   // offset 0x204, size 0x2
+    s16 now_koc;                 // offset 0x206, size 0x2
+    s16 char_index;              // offset 0x208, size 0x2
+    s16 current_colcd;           // offset 0x20A, size 0x2
+    s16 cgd_type;                // offset 0x20C, size 0x2
+    u8 pat_status;               // offset 0x20E, size 0x1
+    u8 kind_of_waza;             // offset 0x20F, size 0x1
+    u8 hit_range;                // offset 0x210, size 0x1
+    u8 total_paring;             // offset 0x211, size 0x1
+    u8 total_att_set;            // offset 0x212, size 0x1
+    u8 sp_tech_id;               // offset 0x213, size 0x1
+    u8 cg_type;                  // offset 0x214, size 0x1
+    u8 cg_ctr;                   // offset 0x215, size 0x1
+    u16 cg_se;                   // offset 0x216, size 0x2
+    u16 cg_olc_ix;               // offset 0x218, size 0x2
+    u16 cg_number;               // offset 0x21A, size 0x2
+    u16 cg_hit_ix;               // offset 0x21C, size 0x2
+    s16 cg_att_ix;               // offset 0x21E, size 0x2
+    u8 cg_extdat;                // offset 0x220, size 0x1
+    u8 cg_cancel;                // offset 0x221, size 0x1
+    u8 cg_effect;                // offset 0x222, size 0x1
+    u8 cg_eftype;                // offset 0x223, size 0x1
+    u16 cg_zoom;                 // offset 0x224, size 0x2
+    u16 cg_rival;                // offset 0x226, size 0x2
+    u16 cg_add_xy;               // offset 0x228, size 0x2
+    u8 cg_next_ix;               // offset 0x22A, size 0x1
+    u8 cg_status;                // offset 0x22B, size 0x1
+    s16 cg_wca_ix;               // offset 0x22C, size 0x2
+    s16 cg_jphos;                // offset 0x22E, size 0x2
+    u16 cg_meoshi;               // offset 0x230, size 0x2
+    u8 cg_prio;                  // offset 0x232, size 0x1
+    u8 cg_flip;                  // offset 0x233, size 0x1
+    u16 old_cgnum;               // offset 0x234, size 0x2
+    s16 floor;                   // offset 0x236, size 0x2
+    u16 ccoff;                   // offset 0x238, size 0x2
+    s16 colcd;                   // offset 0x23A, size 0x2
+    s16 my_col_mode;             // offset 0x23C, size 0x2
+    s16 my_col_code;             // offset 0x23E, size 0x2
+    s16 my_priority;             // offset 0x240, size 0x2
+    s16 my_family;               // offset 0x242, size 0x2
+    s16 my_ext_pri;              // offset 0x244, size 0x2
+    s16 my_bright_type;          // offset 0x246, size 0x2
+    s16 my_bright_level;         // offset 0x248, size 0x2
+    s16 my_clear_level;          // offset 0x24A, size 0x2
+    s16 my_mts;                  // offset 0x24C, size 0x2
+    s16 my_mr_flag;              // offset 0x24E, size 0x2
     struct /* @anon47 */ {
         // total size: 0x4
         struct /* @anon48 */ {
@@ -585,22 +598,36 @@ typedef struct {
 
 typedef struct {
     // total size: 0x46C
-    WORK wu;                // offset 0x0, size 0x388
-    WORK_CP* cp;            // offset 0x388, size 0x4
-    u32 spmv_ng_flag;       // offset 0x38C, size 0x4
-    u32 spmv_ng_flag2;      // offset 0x390, size 0x4
-    s16 player_number;      // offset 0x394, size 0x2
-    s16 zuru_timer;         // offset 0x396, size 0x2
-    u16 zuru_ix_counter;    // offset 0x398, size 0x2
-    u8 zuru_flag;           // offset 0x39A, size 0x1
-    s8 tsukamarenai_flag;   // offset 0x39B, size 0x1
-    u8 kizetsu_kow;         // offset 0x39C, size 0x1
-    u8 micchaku_flag;       // offset 0x39D, size 0x1
-    u8 hos_fi_flag;         // offset 0x39E, size 0x1
-    u8 hos_em_flag;         // offset 0x39F, size 0x1
-    s16 tsukami_num;        // offset 0x3A0, size 0x2
-    s8 tsukami_f;           // offset 0x3A2, size 0x1
-    s8 tsukamare_f;         // offset 0x3A3, size 0x1
+    WORK wu;           // offset 0x0, size 0x388
+    WORK_CP* cp;       // offset 0x388, size 0x4
+    u32 spmv_ng_flag;  // offset 0x38C, size 0x4
+    u32 spmv_ng_flag2; // offset 0x390, size 0x4
+
+    /// Number of the character that the player controls.
+    /// offset 0x394, size 0x2
+    s16 player_number;
+
+    s16 zuru_timer;       // offset 0x396, size 0x2
+    u16 zuru_ix_counter;  // offset 0x398, size 0x2
+    u8 zuru_flag;         // offset 0x39A, size 0x1
+    s8 tsukamarenai_flag; // offset 0x39B, size 0x1
+    u8 kizetsu_kow;       // offset 0x39C, size 0x1
+    u8 micchaku_flag;     // offset 0x39D, size 0x1
+    u8 hos_fi_flag;       // offset 0x39E, size 0x1
+    u8 hos_em_flag;       // offset 0x39F, size 0x1
+
+    /// Number of the character the player is throwing.
+    /// offset 0x3A0, size 0x2
+    s16 tsukami_num;
+
+    /// Flag that's set if the player is throwing the opponent.
+    /// offset 0x3A2, size 0x1
+    s8 tsukami_f;
+
+    /// Flag that's set if the player is being thrown by the opponent.
+    /// offset 0x3A3, size 0x1
+    s8 tsukamare_f;
+
     s8 kind_of_catch;       // offset 0x3A4, size 0x1
     u8 old_gdflag;          // offset 0x3A5, size 0x1
     u8 guard_flag;          // offset 0x3A6, size 0x1
@@ -1610,31 +1637,31 @@ typedef struct {
 
 typedef struct {
     // total size: 0x64
-    u32* nmca;      // offset 0x0, size 0x4
-    u32* dmca;      // offset 0x4, size 0x4
-    u32* btca;      // offset 0x8, size 0x4
-    u32* caca;      // offset 0xC, size 0x4
-    u32* cuca;      // offset 0x10, size 0x4
-    u32* atca;      // offset 0x14, size 0x4
-    u32* saca;      // offset 0x18, size 0x4
-    u32* exca;      // offset 0x1C, size 0x4
-    u32* cbca;      // offset 0x20, size 0x4
-    u32* yuca;      // offset 0x24, size 0x4
-    s16* stxy;      // offset 0x28, size 0x4
-    s16* mvxy;      // offset 0x2C, size 0x4
-    u32* sernd;     // offset 0x30, size 0x4
-    UNK_8* ovct;    // offset 0x34, size 0x4
-    UNK_9* ovix;    // offset 0x38, size 0x4
-    UNK_10* rict;   // offset 0x3C, size 0x4
-    UNK_0* hiit;    // offset 0x40, size 0x4
-    UNK_1* boda;    // offset 0x44, size 0x4
-    UNK_2* hana;    // offset 0x48, size 0x4
-    UNK_3* cata;    // offset 0x4C, size 0x4
-    UNK_4* caua;    // offset 0x50, size 0x4
-    UNK_5* atta;    // offset 0x54, size 0x4
-    UNK_6* hosa;    // offset 0x58, size 0x4
-    UNK_7* atit;    // offset 0x5C, size 0x4
-    UNK_Data* prot; // offset 0x60, size 0x4
+    u32* nmca;        // offset 0x0, size 0x4
+    u32* dmca;        // offset 0x4, size 0x4
+    u32* btca;        // offset 0x8, size 0x4
+    u32* caca;        // offset 0xC, size 0x4
+    u32* cuca;        // offset 0x10, size 0x4
+    u32* atca;        // offset 0x14, size 0x4
+    u32* saca;        // offset 0x18, size 0x4
+    u32* exca;        // offset 0x1C, size 0x4
+    u32* cbca;        // offset 0x20, size 0x4
+    u32* yuca;        // offset 0x24, size 0x4
+    s16* stxy;        // offset 0x28, size 0x4
+    s16* mvxy;        // offset 0x2C, size 0x4
+    u32* sernd;       // offset 0x30, size 0x4
+    UNK_8* ovct;      // offset 0x34, size 0x4
+    UNK_9* ovix;      // offset 0x38, size 0x4
+    CatchTable* rict; // offset 0x3C, size 0x4
+    UNK_0* hiit;      // offset 0x40, size 0x4
+    UNK_1* boda;      // offset 0x44, size 0x4
+    UNK_2* hana;      // offset 0x48, size 0x4
+    UNK_3* cata;      // offset 0x4C, size 0x4
+    UNK_4* caua;      // offset 0x50, size 0x4
+    UNK_5* atta;      // offset 0x54, size 0x4
+    UNK_6* hosa;      // offset 0x58, size 0x4
+    UNK_7* atit;      // offset 0x5C, size 0x4
+    UNK_Data* prot;   // offset 0x60, size 0x4
 } CharInitData;
 
 typedef struct {

--- a/src/anniversary/port/sdl/sdl_app.c
+++ b/src/anniversary/port/sdl/sdl_app.c
@@ -243,7 +243,7 @@ void SDLApp_EndFrame() {
     SDL_SetRenderScale(renderer, 2, 2);
     SDL_RenderDebugTextFormat(renderer, 8, 8, "FPS: %f", fps);
     SDL_RenderDebugTextFormat(renderer, 8, 20, "Render tasks: %d", SDLGameRenderer_GetRenderTaskCount());
-    
+
     if (opening_index >= 0) {
         SDL_RenderDebugTextFormat(renderer, 8, 32, "Opening index: %d", opening_index);
     }
@@ -257,9 +257,10 @@ void SDLApp_EndFrame() {
     if (current_time < frame_deadline) {
         const Uint64 sleep_time = frame_deadline - current_time;
         SDL_DelayNS(sleep_time);
+        frame_deadline += target_frame_time_ns;
+    } else {
+        frame_deadline = current_time + target_frame_time_ns;
     }
-
-    frame_deadline += target_frame_time_ns;
 
     // Measure
     frame_counter += 1;

--- a/src/anniversary/sf33rd/Source/Game/CHARSET.c
+++ b/src/anniversary/sf33rd/Source/Game/CHARSET.c
@@ -2745,9 +2745,9 @@ void check_cgd_patdat2(WORK* wk) {
 
     if (wk->work_id == 1) {
         if (wk->cg_rival == 0) {
-            wk->curr_rca = 0;
+            wk->curr_rca = NULL;
         } else {
-            wk->curr_rca = &wk->rival_catch_tbl[wk->cg_rival - 20 + ((PLW*)wk)->tsukami_num];
+            wk->curr_rca = wk->rival_catch_tbl + (wk->cg_rival - 20 + ((PLW*)wk)->tsukami_num);
         }
     }
 

--- a/src/anniversary/sf33rd/Source/Game/CHARSET.c
+++ b/src/anniversary/sf33rd/Source/Game/CHARSET.c
@@ -2584,7 +2584,7 @@ void check_cgd_patdat(WORK* wk) {
         if (wk->cg_rival == 0) {
             wk->curr_rca = NULL;
         } else {
-            wk->curr_rca = wk->rival_catch_tbl + (wk->cg_rival - 20 + wk[1].before);
+            wk->curr_rca = wk->rival_catch_tbl + (wk->cg_rival - 20 + ((PLW*)wk)->tsukami_num);
         }
 
         wk->cg_olc = wk->olc_ix_table[wk->cg_olc_ix];

--- a/src/anniversary/sf33rd/Source/Game/EFFECT.c
+++ b/src/anniversary/sf33rd/Source/Game/EFFECT.c
@@ -13,7 +13,7 @@ s16 frwctr_min;
 s16 head_ix[8];
 s16 tail_ix[8];
 s16 exec_tm[8];
-u32 frw[EFFECT_MAX][448];
+uintptr_t frw[EFFECT_MAX][448];
 s16 frwque[EFFECT_MAX];
 
 void move_effect_work(s16 index) {
@@ -21,17 +21,19 @@ void move_effect_work(s16 index) {
     s16 curr_ix;
     s16 next_ix;
 
-    if (!Debug_w[0x28]) {
-        exec_tm[index] += 1;
+    if (Debug_w[0x28]) {
+        return;
+    }
 
-        for (curr_ix = head_ix[index]; curr_ix != -1; curr_ix = next_ix) {
-            c_addr = (WORK*)frw[curr_ix];
-            next_ix = c_addr->behind;
+    exec_tm[index] += 1;
 
-            if (c_addr->timing != exec_tm[index]) {
-                c_addr->timing = exec_tm[index];
-                effmovejptbl[c_addr->id](c_addr);
-            }
+    for (curr_ix = head_ix[index]; curr_ix != -1; curr_ix = next_ix) {
+        c_addr = (WORK*)frw[curr_ix];
+        next_ix = c_addr->behind;
+
+        if (c_addr->timing != exec_tm[index]) {
+            c_addr->timing = exec_tm[index];
+            effmovejptbl[c_addr->id](c_addr);
         }
     }
 }
@@ -44,25 +46,28 @@ void disp_effect_work() {
     s32 px;
     s32 py;
 
-    if (Debug_w[0x29] != 0) {
-        px = 7;
-        py = 15;
-        for (index = 0; index <= 7; index += 1) {
-            curr_ix = head_ix[index];
-            px += 5;
-            py = 14;
-            for (curr_ix; curr_ix != -1; curr_ix = next_ix) {
+    if (Debug_w[0x29] == 0) {
+        return;
+    }
 
-                if (py > 49) {
-                    py = 14;
-                    px += 3;
-                }
+    px = 7;
+    py = 15;
 
-                c_addr = (WORK*)frw[curr_ix];
-                next_ix = c_addr->behind;
-                flPrintL(px, py, "%c%d", "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"[(c_addr->id / 10)], c_addr -> id % 10);
-                py++;
+    for (index = 0; index <= 7; index += 1) {
+        curr_ix = head_ix[index];
+        px += 5;
+        py = 14;
+
+        for (curr_ix; curr_ix != -1; curr_ix = next_ix) {
+            if (py > 49) {
+                py = 14;
+                px += 3;
             }
+
+            c_addr = (WORK*)frw[curr_ix];
+            next_ix = c_addr->behind;
+            flPrintL(px, py, "%c%d", "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"[(c_addr->id / 10)], c_addr -> id % 10);
+            py++;
         }
     }
 }
@@ -205,6 +210,12 @@ void push_effect_work(WORK* wkhd) {
     lix = wkhd->listix;
     qix = wkhd->myself;
     c_addr = (WORK*)frw[qix];
+
+#if !defined(TARGET_PS2)
+    if (qix < 0 || qix >= 128) {
+        fatal_error("qix is out of range");
+    }
+#endif
 
     switch ((qix == head_ix[lix]) + (qix == tail_ix[lix]) * 2) {
     case 0:

--- a/src/anniversary/sf33rd/Source/Game/EFFECT.c
+++ b/src/anniversary/sf33rd/Source/Game/EFFECT.c
@@ -120,19 +120,19 @@ void effect_work_list_init(s16 lix, s16 iid) {
             push_effect_work(c_addr);
             curr_ix = next_ix;
         }
+
         exec_tm[lix] = 0;
-        return;
-    }
+    } else {
+        while (curr_ix != -1) {
+            c_addr = (WORK*)frw[curr_ix];
+            next_ix = c_addr->behind;
 
-    while (curr_ix != -1) {
-        c_addr = (WORK*)frw[curr_ix];
-        next_ix = c_addr->behind;
+            if (c_addr->id == iid) {
+                push_effect_work(c_addr);
+            }
 
-        if (c_addr->id == iid) {
-            push_effect_work(c_addr);
+            curr_ix = next_ix;
         }
-
-        curr_ix = next_ix;
     }
 }
 
@@ -168,6 +168,11 @@ s16 pull_effect_work(s16 index) {
     return qix;
 }
 
+/// @brief Searches for an effect.
+/// @param index Index of the list to perform search in.
+/// @param flag Set to `true` to search from the tail, `false` to search from the head.
+/// @param tid ID to search for.
+/// @return Index of the effect, or `-1` if it couldn't be found.
 s16 search_effect_index(s16 index, s16 flag, s16 tid) {
     WORK* c_addr;
     s16 aix;

--- a/src/anniversary/sf33rd/Source/Game/EFFK5.c
+++ b/src/anniversary/sf33rd/Source/Game/EFFK5.c
@@ -77,7 +77,14 @@ void effect_K5_move(WORK_Other* ewk) {
             return;
         }
 
-        mvj = (MVJ*)(ewk->wu.target_adrs + 9);
+        // This line is bullshit. Effect K5 needs some space for MVJ manipulation. Instead of allocating
+        // space for that somewhere else they decided to use some of the space dedicated to effect work.
+        // Why did they choose routine_no as the starting offset specifically? They did that because it's
+        // the first var of WORK that is not used for effect scheduling. If they chose an earlier address
+        // that would lead to crashes and infinite loops. Fun times!
+        // There's one more line just like this one down below.
+        mvj = (MVJ*)(((WORK*)ewk->wu.target_adrs)->routine_no);
+
         init_K5_work(&ewk->wu, mwk, mvj);
         ewk->wu.old_rno[1] = mwk->cg_hit_ix;
         get_table_adrs_K5(mwk);
@@ -98,7 +105,7 @@ void effect_K5_move(WORK_Other* ewk) {
         }
 
         get_master_table_address(&ewk->wu, mwk);
-        mvj = (MVJ*)(ewk->wu.target_adrs + 9);
+        mvj = (MVJ*)(((WORK*)ewk->wu.target_adrs)->routine_no);
 
         if (mwk->K5_exec_ok) {
             mwk->K5_exec_ok = 0;

--- a/src/anniversary/sf33rd/Source/Game/MTRANS.c
+++ b/src/anniversary/sf33rd/Source/Game/MTRANS.c
@@ -357,7 +357,7 @@ s16 getObjectHeight(u16 cgnum) {
     }
 
     cgnum -= texgrpdat[i].num_of_1st;
-    trsbas = (u16*)((char*)texgrplds[i].trans_table + ((u32*)texgrplds[i].trans_table)[cgnum]);
+    trsbas = (u16*)((s8*)texgrplds[i].trans_table + ((u32*)texgrplds[i].trans_table)[cgnum]);
     count = *trsbas;
     trsbas++;
     trsptr = (TileMapEntry*)trsbas;

--- a/src/anniversary/sf33rd/Source/Game/eff05.c
+++ b/src/anniversary/sf33rd/Source/Game/eff05.c
@@ -116,8 +116,7 @@ s32 effect_05_init() {
             return -1;
         }
 
-        ewk = (WORK_Other*)((u8*)&frw + ix * 0x700);
-
+        ewk = (WORK_Other*)frw[ix];
         ewk->wu.be_flag = 1;
         ewk->wu.id = 5;
         ewk->wu.work_id = 0x10;

--- a/src/anniversary/sf33rd/Source/Game/eff36.c
+++ b/src/anniversary/sf33rd/Source/Game/eff36.c
@@ -364,7 +364,7 @@ s32 effect_36_init(u8 typenum) {
         return -1;
     }
 
-    ewk = (WORK_Other*)&frw[ix];
+    ewk = (WORK_Other*)frw[ix];
     data_ptr = eff36_data_tbl[typenum];
     ewk->wu.id = 0x24;
     ewk->wu.be_flag = 1;

--- a/src/anniversary/sf33rd/Source/Game/efff6.c
+++ b/src/anniversary/sf33rd/Source/Game/efff6.c
@@ -237,7 +237,7 @@ s32 effect_F6_init(u8 typenum) {
         return -1;
     }
 
-    ewk = (WORK_Other*)&frw[ix];
+    ewk = (WORK_Other*)frw[ix];
     data_ptr = efff6_data_tbl00[typenum];
     ewk->wu.id = 0x9C;
     ewk->wu.be_flag = 1;


### PR DESCRIPTION
- Increased the size of `frw` to account for pointers being bigger on modern platforms. This should prevent some bugs
- Fixed catch table offset not being calculated properly. This fixes throws. Thanks to drewdos for spotting the issue
- Adjusted FPS limiter logic. Now slowdowns don't cause a speedup afterwards
- Added docstrings to some vars/funcs
- Fixed offset calculation for MVJ manipulation area in EFFK5. This fixes related crashes and infinite loops