### PR TITLE
Port: Only recreate textures on unlock

### DIFF
--- a/include/port/sdl/sdl_game_renderer.h
+++ b/include/port/sdl/sdl_game_renderer.h
@@ -48,10 +48,11 @@ void SDLGameRenderer_EndFrame();
 
 void SDLGameRenderer_CreateTexture(unsigned int th);
 void SDLGameRenderer_DestroyTexture(unsigned int texture_handle);
+void SDLGameRenderer_UnlockTexture(unsigned int th);
 void SDLGameRenderer_CreatePalette(unsigned int ph);
 void SDLGameRenderer_DestroyPalette(unsigned int palette_handle);
+void SDLGameRenderer_UnlockPalette(unsigned int ph);
 void SDLGameRenderer_SetTexture(unsigned int th);
-void SDLGameRenderer_ReloadTexture(unsigned int th);
 void SDLGameRenderer_DrawTexturedQuad(const SDLGameRenderer_Vertex* vertices);
 void SDLGameRenderer_DrawSolidQuad(const SDLGameRenderer_Vertex* vertices);
 void SDLGameRenderer_DrawSprite(const SDLGameRenderer_Sprite* sprite, unsigned int color);

--- a/src/anniversary/port/sdl/sdl_game_renderer.c
+++ b/src/anniversary/port/sdl/sdl_game_renderer.c
@@ -264,6 +264,26 @@ void SDLGameRenderer_EndFrame() {
     clear_render_tasks();
 }
 
+void SDLGameRenderer_UnlockPalette(unsigned int ph) {
+    const int palette_handle = ph;
+    if ((palette_handle > 0) && (palette_handle < FL_PALETTE_MAX)) {
+        const FLTexture* fl_palette = &flPalette[palette_handle - 1];
+
+        SDLGameRenderer_DestroyPalette(palette_handle);
+        SDLGameRenderer_CreatePalette(ph << 16);
+    }
+}
+
+void SDLGameRenderer_UnlockTexture(unsigned int th) {
+    const int texture_handle = th;
+    if ((texture_handle > 0) && (texture_handle < FL_TEXTURE_MAX)) {
+        const FLTexture* fl_texture = &flTexture[texture_handle - 1];
+
+        SDLGameRenderer_DestroyTexture(texture_handle);
+        SDLGameRenderer_CreateTexture(th);
+    }
+}
+
 void SDLGameRenderer_CreateTexture(unsigned int th) {
     const int texture_index = LO_16_BITS(th) - 1;
     const FLTexture* fl_texture = &flTexture[texture_index];
@@ -416,34 +436,6 @@ void SDLGameRenderer_SetTexture(unsigned int th) {
     }
 
     push_texture(texture);
-}
-
-void SDLGameRenderer_ReloadTexture(unsigned int th) {
-    const int texture_handle = LO_16_BITS(th);
-    const int palette_handle = HI_16_BITS(th);
-
-    // Kludge to reduce texture re-creation caused by scfont_put
-    if (((texture_handle == 2) || (texture_handle == 4)) && ((palette_handle == 805) || (palette_handle == 806))) {
-        return;
-    }
-
-    if ((texture_handle > 0) && (texture_handle < FL_TEXTURE_MAX)) {
-        const FLTexture* fl_texture = &flTexture[texture_handle - 1];
-
-        if (!fl_texture->vram_on_flag) {
-            SDLGameRenderer_DestroyTexture(texture_handle);
-            SDLGameRenderer_CreateTexture(th);
-        }
-    }
-
-    if ((palette_handle > 0) && (palette_handle < FL_PALETTE_MAX)) {
-        const FLTexture* fl_palette = &flPalette[palette_handle - 1];
-
-        if (!fl_palette->vram_on_flag) {
-            SDLGameRenderer_DestroyPalette(palette_handle);
-            SDLGameRenderer_CreatePalette(th);
-        }
-    }
 }
 
 static void draw_quad(const SDLGameRenderer_Vertex* vertices, bool textured) {

--- a/src/anniversary/sf33rd/AcrSDK/ps2/flps2vram.c
+++ b/src/anniversary/sf33rd/AcrSDK/ps2/flps2vram.c
@@ -1058,7 +1058,14 @@ s32 flUnlockTexture(u32 th) {
         return 0;
     }
 
+  
+#if defined(TARGET_PS2)
     return flPS2UnlockTexture(lpflTexture);
+#else
+    int ret = flPS2UnlockTexture(lpflTexture);
+    SDLGameRenderer_UnlockTexture(th);
+    return ret;
+#endif
 }
 
 s32 flUnlockPalette(u32 th) {
@@ -1072,7 +1079,13 @@ s32 flUnlockPalette(u32 th) {
         return 0;
     }
 
+#if defined(TARGET_PS2)
     return flPS2UnlockTexture(lpflPalette);
+#else
+    int ret = flPS2UnlockTexture(lpflPalette);
+    SDLGameRenderer_UnlockPalette(th);
+    return ret;
+#endif
 }
 
 s32 flPS2UnlockTexture(FLTexture* lpflTexture) {
@@ -1352,8 +1365,6 @@ s32 flPS2ReloadTexture(s32 count, u32* texlist) {
                 flDebugRTNum += 1;
             }
         }
-#else
-        SDLGameRenderer_ReloadTexture(th);
 #endif
     }
 


### PR DESCRIPTION
This is a hefty performance boost.

The game uses [Lock/Unlock]Texture to handle modifying textures, so pretty sure we only need to recreate textures after an Unlock operation.

The purpose of ReloadTexture seems to be to make it resident in PS2 VRAM, which is going to happen any time it changes the currently bound texture. I don't think we need to do anything in this case. (Unless they did something silly)