### PR TITLE
Correct the color channel order in `read_rgba32_color` 

### DIFF
--- a/src/anniversary/port/sdl/sdl_game_renderer.c
+++ b/src/anniversary/port/sdl/sdl_game_renderer.c
@@ -153,9 +153,9 @@ static int compare_render_tasks(const RenderTask* a, const RenderTask* b) {
 #define clut_shuf(x) (((x) & ~0x18) | ((((x) & 0x08) << 1) | (((x) & 0x10) >> 1)))
 
 static void read_rgba32_color(Uint32 pixel, SDL_Color* color) {
-    color->r = pixel & 0xFF;
+    color->b = pixel & 0xFF;
     color->g = (pixel >> 8) & 0xFF;
-    color->b = (pixel >> 16) & 0xFF;
+    color->r = (pixel >> 16) & 0xFF;
     color->a = (pixel >> 24) & 0xFF;
 }
 


### PR DESCRIPTION
The PS2's `PSMCT32` pixel format is BGRA, but the `read_rgba32_color` function was incorrectly reading it as RGBA. This change swaps the red and blue channel assignments to correctly parse the color data.

