### PR TITLE
Various fixes

### DIFF
--- a/src/anniversary/port/sdl/sdl_adx_sound.c
+++ b/src/anniversary/port/sdl/sdl_adx_sound.c
@@ -418,6 +418,8 @@ void SDLADXSound_Pause(int pause) {
 }
 
 void SDLADXSound_StartMem(void* buf, size_t size) {
+    SDLADXSound_Stop();
+
     ADXTrack* track = alloc_track();
     track_init(track, -1, buf, size, true);
 }

--- a/src/anniversary/sf33rd/Source/Game/sc_sub.c
+++ b/src/anniversary/sf33rd/Source/Game/sc_sub.c
@@ -841,7 +841,14 @@ void stun_put(u8 Pl_Num, u8 stun) {
 
     ppgSetupCurrentDataList(&ppgScrList);
     setFilterMode(0);
+
+#if defined(TARGET_PS2)
     scrscrntex[0].z = scrscrntex[3].z = PrioBase[4];
+#else
+    // Decreasing z by a tiny value brings stun gauge a bit closer to the screen, eliminating z-fighting
+    scrscrntex[0].z = scrscrntex[3].z = PrioBase[4] - 0.1f;
+#endif
+
     njSetPaletteBankNumG(0, 10);
     scrscrntex[0].u = 0.0f;
     scrscrntex[3].u = 8.0f / 256.0f;

--- a/src/anniversary/sf33rd/Source/Game/texgroup.c
+++ b/src/anniversary/sf33rd/Source/Game/texgroup.c
@@ -294,15 +294,17 @@ void q_ldreq_texture_group(REQ* curr) {
 
                 parabora_own_table[plt_req[curr->id]] = cit2->prot;
 
+                // Q specific code
                 if (curr->ix == 18) {
-#if !defined(TARGET_PS2)
-                    fatal_error("This code is highly suspicious. Investigate it before removing this error");
-#endif
+#if defined(TARGET_PS2)
                     patchAdrs = ((u32**)ldchd)[8];
                     patchAdrs[37] = patchAdrs[3];
+#else
+                    cit2->cbca[37] = cit2->cbca[3];
+#endif
                 }
 
-                // Looks like this code handles some Akuma specific stuff
+                // Akuma specific code
                 if (curr->ix == 15) {
                     trsbas = (u16*)(((u32*)texgrplds[15].trans_table)[166] + texgrplds[15].trans_table);
                     count = *trsbas;


### PR DESCRIPTION
- Current ADX track now stops when starting playback from memory. This is exactly how the original implementation from CRI works. It fixes getting stuck in an infinite loop after picking a character
- Added a proper implementation for Q specific code in `q_ldreq_texture_group`
- Eliminated stun gauge flicker, that occurred due to z-fighting