### PR TITLE
Port 19

### DIFF
--- a/include/port/sdl/sdl_app.h
+++ b/include/port/sdl/sdl_app.h
@@ -7,6 +7,4 @@ int SDLApp_PollEvents();
 void SDLApp_BeginFrame();
 void SDLApp_EndFrame();
 
-void SDLApp_SetOpeningIndex(int index);
-
 #endif

--- a/include/port/sdl/sdl_game_renderer.h
+++ b/include/port/sdl/sdl_game_renderer.h
@@ -58,6 +58,4 @@ void SDLGameRenderer_DrawSolidQuad(const SDLGameRenderer_Vertex* vertices);
 void SDLGameRenderer_DrawSprite(const SDLGameRenderer_Sprite* sprite, unsigned int color);
 void SDLGameRenderer_DrawSprite2(const SDLGameRenderer_Sprite2* sprite2);
 
-int SDLGameRenderer_GetRenderTaskCount();
-
 #endif

--- a/src/anniversary/port/sdl/sdl_app.c
+++ b/src/anniversary/port/sdl/sdl_app.c
@@ -11,7 +11,7 @@
 
 #include <SDL3/SDL.h>
 
-#define FRAME_END_TIMES_MAX 120
+#define FRAME_END_TIMES_MAX 30
 
 // We can't include cri_mw.h because it leads to conflicts
 // with SDL types
@@ -21,14 +21,13 @@ static const char* app_name = "Street Fighter III: 3rd Strike";
 static const float display_target_ratio = 4.0 / 3.0;
 static const int window_default_width = 640;
 static const int window_default_height = (int)(window_default_width / display_target_ratio);
-static const int target_fps = 60;
+static const double target_fps = 59.59949;
 static const Uint64 target_frame_time_ns = 1000000000.0 / target_fps;
 
 static SDL_Window* window = NULL;
 static SDL_Renderer* renderer = NULL;
 static SDL_Texture* screen_texture = NULL;
 
-static Uint64 frame_start = 0;
 static Uint64 frame_deadline = 0;
 static Uint64 frame_end_times[FRAME_END_TIMES_MAX];
 static int frame_end_times_index = 0;
@@ -139,12 +138,6 @@ int SDLApp_PollEvents() {
 }
 
 void SDLApp_BeginFrame() {
-    frame_start = SDL_GetTicksNS();
-
-    if (frame_deadline == 0) {
-        frame_deadline = frame_start + target_frame_time_ns;
-    }
-
     // Clear window
     SDL_SetRenderDrawColor(renderer, 0, 0, 0, SDL_ALPHA_OPAQUE);
     SDL_SetRenderTarget(renderer, NULL);
@@ -190,12 +183,12 @@ static void update_fps() {
     double total_frame_time_ms = 0;
 
     for (int i = 0; i < FRAME_END_TIMES_MAX - 1; i++) {
-        const int cur = frame_end_times_index;
+        const int cur = (frame_end_times_index + i) % FRAME_END_TIMES_MAX;
         const int next = (cur + 1) % FRAME_END_TIMES_MAX;
-        total_frame_time_ms += (double)(frame_end_times[next] - frame_end_times[cur]) / 1000000;
+        total_frame_time_ms += (double)(frame_end_times[next] - frame_end_times[cur]) / 1e6;
     }
 
-    double average_frame_time_ms = total_frame_time_ms / FRAME_END_TIMES_MAX;
+    double average_frame_time_ms = total_frame_time_ms / (FRAME_END_TIMES_MAX - 1);
     fps = 1000 / average_frame_time_ms;
 }
 
@@ -250,22 +243,32 @@ void SDLApp_EndFrame() {
 
     SDL_RenderPresent(renderer);
 
-    const Uint64 current_time = SDL_GetTicksNS();
+    // Cleanup
+    SDLGameRenderer_EndFrame();
+    should_save_screenshot = false;
 
-    if (current_time < frame_deadline) {
-        const Uint64 sleep_time = frame_deadline - current_time;
+    // Do frame pacing
+    Uint64 now = SDL_GetTicksNS();
+
+    if (frame_deadline == 0) {
+        frame_deadline = now + target_frame_time_ns;
+    }
+
+    if (now < frame_deadline) {
+        Uint64 sleep_time = frame_deadline - now;
         SDL_DelayNS(sleep_time);
-        frame_deadline += target_frame_time_ns;
-    } else {
-        frame_deadline = current_time + target_frame_time_ns;
+        now = SDL_GetTicksNS();
+    }
+
+    frame_deadline += target_frame_time_ns;
+
+    // If we fell behind by more than one frame, resync to avoid spiraling
+    if (now > frame_deadline + target_frame_time_ns) {
+        frame_deadline = now + target_frame_time_ns;
     }
 
     // Measure
     frame_counter += 1;
     note_frame_end_time();
     update_fps();
-
-    // Cleanup
-    SDLGameRenderer_EndFrame();
-    should_save_screenshot = false;
 }

--- a/src/anniversary/port/sdl/sdl_app.c
+++ b/src/anniversary/port/sdl/sdl_app.c
@@ -36,7 +36,6 @@ static bool frame_end_times_filled = false;
 static double fps = 0;
 static Uint64 frame_counter = 0;
 
-static int opening_index = -1;
 static bool should_save_screenshot = false;
 
 static void create_screen_texture() {
@@ -246,13 +245,7 @@ void SDLApp_EndFrame() {
     // Render metrics
     SDL_SetRenderDrawColor(renderer, 255, 255, 255, SDL_ALPHA_OPAQUE);
     SDL_SetRenderScale(renderer, 2, 2);
-    SDL_RenderDebugTextFormat(renderer, 8, 8, "FPS: %f", fps);
-    SDL_RenderDebugTextFormat(renderer, 8, 20, "Render tasks: %d", SDLGameRenderer_GetRenderTaskCount());
-
-    if (opening_index >= 0) {
-        SDL_RenderDebugTextFormat(renderer, 8, 32, "Opening index: %d", opening_index);
-    }
-
+    SDL_RenderDebugTextFormat(renderer, 8, 8, "FPS: %.3f", fps);
     SDL_SetRenderScale(renderer, 1, 1);
 
     SDL_RenderPresent(renderer);
@@ -275,8 +268,4 @@ void SDLApp_EndFrame() {
     // Cleanup
     SDLGameRenderer_EndFrame();
     should_save_screenshot = false;
-}
-
-void SDLApp_SetOpeningIndex(int index) {
-    opening_index = index;
 }

--- a/src/anniversary/port/sdl/sdl_game_renderer.c
+++ b/src/anniversary/port/sdl/sdl_game_renderer.c
@@ -520,7 +520,3 @@ void SDLGameRenderer_DrawSprite2(const SDLGameRenderer_Sprite2* sprite2) {
 
     SDLGameRenderer_DrawSprite(&sprite, sprite2->vertex_color);
 }
-
-int SDLGameRenderer_GetRenderTaskCount() {
-    return render_task_count;
-}

--- a/src/anniversary/port/sdl/sdl_game_renderer.c
+++ b/src/anniversary/port/sdl/sdl_game_renderer.c
@@ -17,6 +17,7 @@ typedef struct RenderTask {
     SDL_Texture* texture;
     SDL_Vertex vertices[4];
     float z;
+    int index;
 } RenderTask;
 
 SDL_Texture* cps3_canvas = NULL;
@@ -144,7 +145,14 @@ static int compare_render_tasks(const RenderTask* a, const RenderTask* b) {
     } else if (a->z > b->z) {
         return 1;
     } else {
-        return 0;
+        // This eliminates z-fighting
+        if (a->index < b->index) {
+            return 1;
+        } else if (a->index > b->index) {
+            return -1;
+        } else {
+            return 0;
+        }
     }
 }
 
@@ -440,6 +448,7 @@ void SDLGameRenderer_SetTexture(unsigned int th) {
 
 static void draw_quad(const SDLGameRenderer_Vertex* vertices, bool textured) {
     RenderTask task;
+    task.index = render_task_count;
     task.texture = textured ? get_texture() : NULL;
     task.z = flPS2ConvScreenFZ(vertices[0].coord.z);
 

--- a/src/anniversary/sf33rd/Source/Game/OPENING.c
+++ b/src/anniversary/sf33rd/Source/Game/OPENING.c
@@ -28,10 +28,6 @@
 #include "sf33rd/Source/Game/texcash.h"
 #include "sf33rd/Source/Game/workuser.h"
 
-#if !defined(TARGET_PS2)
-#include "port/sdl/sdl_app.h"
-#endif
-
 typedef const f32* ro_f32_ptr;
 
 #if defined(TARGET_PS2)
@@ -1981,10 +1977,6 @@ void op_118_move() {
 }
 
 void op_bg_move(s16 r_index) {
-#if !defined(TARGET_PS2)
-    SDLApp_SetOpeningIndex(r_index);
-#endif
-
     op_bg0_move(r_index);
     op_bg1_move(r_index);
     op_bg2_move(r_index);

--- a/src/anniversary/sf33rd/Source/Game/sc_sub.c
+++ b/src/anniversary/sf33rd/Source/Game/sc_sub.c
@@ -841,14 +841,7 @@ void stun_put(u8 Pl_Num, u8 stun) {
 
     ppgSetupCurrentDataList(&ppgScrList);
     setFilterMode(0);
-
-#if defined(TARGET_PS2)
     scrscrntex[0].z = scrscrntex[3].z = PrioBase[4];
-#else
-    // Decreasing z by a tiny value brings stun gauge a bit closer to the screen, eliminating z-fighting
-    scrscrntex[0].z = scrscrntex[3].z = PrioBase[4] - 0.1f;
-#endif
-
     njSetPaletteBankNumG(0, 10);
     scrscrntex[0].u = 0.0f;
     scrscrntex[3].u = 8.0f / 256.0f;


### PR DESCRIPTION
- Simplified diagnostic info displayed in the top-left corner
- Fixed z-fighting by honoring quad drawing order
- Fixed FPS counting logic. It used to overestimate FPS
- Set FPS target to 59.59949 to match the arcade